### PR TITLE
feat(oidc): Add support for entra id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,12 +25,18 @@ SPOTIFY_REDIRECT_URI=
 SESSION_SECRET=secret
 COOKIE_SECRET=secret
 
-; Provider can be ENTRA_ID or KEYCLOAK
+; Provider can be ENTRA_ID or KEYCLOAK. More information: https://github.com/GEWIS/aurora-core/wiki/Authentication-&-permissions
 OIDC_PROVIDER=KEYCLOAK
 OIDC_CONFIG=https://auth.gewis.nl/realms/GEWISWG/.well-known/openid-configuration/
 OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
 OIDC_REDIRECT_URI=http://localhost:3000/auth/callback
+
+ROLE_ADMIN="PRIV - Narrowcasting Prod Admin"
+ROLE_BOARD="PRIV - Narrowcasting Prod Board"
+ROLE_KEY_HOLDER="PRIV - Narrowcasting Prod KeyHolder"
+ROLE_BAC="PRIV - Narrowcasting Prod BAC"
+ROLE_AVICO="PRIV - Narrowcasting Prod AViCo"
 
 TRELLO_KEY=
 TRELLO_BOARD_ID=
@@ -40,12 +46,6 @@ TRELLO_BASE_POSTER_LIST_NAME=BasePosters
 
 NS_KEY=
 GEWIS_KEY=
-
-ROLE_ADMIN="PRIV - Narrowcasting Prod Admin"
-ROLE_BOARD="PRIV - Narrowcasting Prod Board"
-ROLE_KEY_HOLDER="PRIV - Narrowcasting Prod KeyHolder"
-ROLE_BAC="PRIV - Narrowcasting Prod BAC"
-ROLE_AVICO="PRIV - Narrowcasting Prod AViCo"
 
 LDAP_ENABLED=
 LDAP_BIND_DN=

--- a/.env.example
+++ b/.env.example
@@ -25,11 +25,10 @@ SPOTIFY_REDIRECT_URI=
 SESSION_SECRET=secret
 COOKIE_SECRET=secret
 
-KEYCLOAK_INFO=https://auth.gewis.nl/realms/GEWISWG/.well-known/openid-configuration/
-KEYCLOAK_AUTH_URI=https://auth.gewis.nl/realms/GEWISWG/protocol/openid-connect/auth
-KEYCLOAK_CLIENT_ID=
-KEYCLOAK_CLIENT_SECRET=
-KEYCLOAK_REDIRECT_URI=http://localhost:3000/auth/callback
+OIDC_CONFIG=https://auth.gewis.nl/realms/GEWISWG/.well-known/openid-configuration/
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_REDIRECT_URI=http://localhost:3000/auth/callback
 
 TRELLO_KEY=
 TRELLO_BOARD_ID=

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ SPOTIFY_REDIRECT_URI=
 SESSION_SECRET=secret
 COOKIE_SECRET=secret
 
+; Provider can be ENTRA_ID or KEYCLOAK
+OIDC_PROVIDER=KEYCLOAK
 OIDC_CONFIG=https://auth.gewis.nl/realms/GEWISWG/.well-known/openid-configuration/
 OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=

--- a/src/modules/auth/auth-controller.ts
+++ b/src/modules/auth/auth-controller.ts
@@ -1,5 +1,7 @@
 import { Controller } from '@tsoa/runtime';
 import { Get, Route, Tags } from 'tsoa';
+import AuthService from "./auth-service";
+import {HttpApiException, HttpStatusCode} from "../../helpers/customError";
 
 interface OidcConfig {
   clientId: string;
@@ -11,11 +13,22 @@ interface OidcConfig {
 @Tags('Authentication')
 export class AuthController extends Controller {
   @Get('oidc')
-  public getOidcParameters(): OidcConfig {
+  public async getOidcParameters(): Promise<OidcConfig> {
+    let oidcConfig;
+
+    try {
+      oidcConfig = await new AuthService().getOIDCConfig();
+    } catch (e) {
+      throw new HttpApiException(
+          HttpStatusCode.InternalServerError,
+          'Cannot get OIDC configuration.',
+      );
+    }
+
     return {
-      clientId: process.env.KEYCLOAK_CLIENT_ID || '',
-      redirectUri: process.env.KEYCLOAK_REDIRECT_URI || '',
-      authUrl: process.env.KEYCLOAK_AUTH_URI || '',
+      clientId: process.env.OIDC_CLIENT_ID || '',
+      redirectUri: process.env.OIDC_REDIRECT_URI || '',
+      authUrl: oidcConfig!.authorization_endpoint || '',
     };
   }
 }

--- a/src/modules/auth/auth-controller.ts
+++ b/src/modules/auth/auth-controller.ts
@@ -28,7 +28,7 @@ export class AuthController extends Controller {
     return {
       clientId: process.env.OIDC_CLIENT_ID || '',
       redirectUri: process.env.OIDC_REDIRECT_URI || '',
-      authUrl: oidcConfig!.authorization_endpoint || '',
+      authUrl: oidcConfig.authorization_endpoint || '',
     };
   }
 }

--- a/src/modules/auth/auth-controller.ts
+++ b/src/modules/auth/auth-controller.ts
@@ -1,7 +1,7 @@
 import { Controller } from '@tsoa/runtime';
 import { Get, Route, Tags } from 'tsoa';
 import AuthService from "./auth-service";
-import {HttpApiException, HttpStatusCode} from "../../helpers/customError";
+import { HttpApiException, HttpStatusCode } from "../../helpers/customError";
 
 interface OidcConfig {
   clientId: string;

--- a/src/modules/auth/auth-service.ts
+++ b/src/modules/auth/auth-service.ts
@@ -4,6 +4,11 @@ import { ApiKey } from './entities';
 import dataSource from '../../database';
 import { Audio, LightsController, Screen } from '../root/entities';
 
+export interface OidcConfig {
+  authorization_endpoint: string;
+  token_endpoint: string;
+}
+
 export interface GenerateApiKeyParams {
   audio?: Audio | null;
   screen?: Screen | null;
@@ -42,5 +47,10 @@ export default class AuthService {
     return this.apiKeyRepository.findOne({
       where: { lightsController: { id: lightsController.id } },
     });
+  }
+
+  public async getOIDCConfig(): Promise<OidcConfig> {
+    const oidcConfigRes = await fetch(process.env.OIDC_CONFIG!);
+    return await oidcConfigRes.json();
   }
 }

--- a/src/modules/auth/auth-service.ts
+++ b/src/modules/auth/auth-service.ts
@@ -51,6 +51,6 @@ export default class AuthService {
 
   public async getOIDCConfig(): Promise<OidcConfig> {
     const oidcConfigRes = await fetch(process.env.OIDC_CONFIG!);
-    return await oidcConfigRes.json();
+    return oidcConfigRes.json();
   }
 }

--- a/src/modules/auth/passport/oidc-strategy.ts
+++ b/src/modules/auth/passport/oidc-strategy.ts
@@ -55,9 +55,9 @@ passport.use(
         method: 'POST',
         body: new URLSearchParams({
           grant_type: 'authorization_code',
-          client_id: process.env.KEYCLOAK_CLIENT_ID!,
-          client_secret: process.env.KEYCLOAK_CLIENT_SECRET!,
-          redirect_uri: process.env.KEYCLOAK_REDIRECT_URI!,
+          client_id: process.env.OIDC_CLIENT_ID!,
+          client_secret: process.env.OIDC_CLIENT_SECRET!,
+          redirect_uri: process.env.OIDC_REDIRECT_URI!,
           code: req.body.code,
         }),
         headers: {
@@ -70,7 +70,7 @@ passport.use(
       const oidcData = await oidcResponse.json();
       const tokenDetails = jwtDecode<AuthStoreToken>(oidcData!.id_token);
       const oidcRoles = tokenDetails.resource_access
-        ? tokenDetails.resource_access[process.env.KEYCLOAK_CLIENT_ID || ''].roles
+        ? tokenDetails.resource_access[process.env.OIDC_CLIENT_ID || ''].roles
         : [];
       const securityRoles = parseRoles(oidcRoles);
 

--- a/src/modules/auth/passport/oidc-strategy.ts
+++ b/src/modules/auth/passport/oidc-strategy.ts
@@ -39,8 +39,18 @@ passport.use(
       );
     }
 
+    const oidcConfigRes = await fetch(process.env.OIDC_CONFIG);
+    let oidcConfig;
+
+    try {
+        oidcConfig = await oidcConfigRes.json();
+    } catch (e) {
+        logger.error(e);
+        req.res?.sendStatus(500);
+    }
+
     const oidcResponse = await fetch(
-      'https://auth.gewis.nl/realms/GEWISWG/protocol/openid-connect/token',
+        oidcConfig.authorization_endpoint,
       {
         method: 'POST',
         body: new URLSearchParams({

--- a/src/modules/auth/passport/oidc-strategy.ts
+++ b/src/modules/auth/passport/oidc-strategy.ts
@@ -60,6 +60,7 @@ passport.use(
           client_secret: process.env.OIDC_CLIENT_SECRET!,
           redirect_uri: process.env.OIDC_REDIRECT_URI!,
           code: req.body.code,
+          scope: 'openid profile user.read'
         }),
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -72,7 +73,7 @@ passport.use(
 
       const tokenDetails = jwtDecode<AuthStoreToken>(oidcData!.id_token);
       let oidcRoles;
-
+      console.log(tokenDetails)
       switch (process.env.OIDC_PROVIDER) {
           case 'KEYCLOAK': {
               oidcRoles = tokenDetails.resource_access

--- a/src/modules/auth/passport/oidc-strategy.ts
+++ b/src/modules/auth/passport/oidc-strategy.ts
@@ -85,9 +85,9 @@ passport.use(
         method: 'POST',
         body: new URLSearchParams({
           grant_type: 'authorization_code',
-          client_id: process.env.OIDC_CLIENT_ID!,
-          client_secret: process.env.OIDC_CLIENT_SECRET!,
-          redirect_uri: process.env.OIDC_REDIRECT_URI!,
+          client_id: process.env.OIDC_CLIENT_ID,
+          client_secret: process.env.OIDC_CLIENT_SECRET,
+          redirect_uri: process.env.OIDC_REDIRECT_URI,
           code: req.body.code,
           scope: 'openid profile user.read'
         }),
@@ -101,7 +101,7 @@ passport.use(
       const oidcData = await oidcResponse.json();
 
       const tokenDetails = jwtDecode<AuthStoreToken>(oidcData!.id_token);
-      let oidcRoles;
+      let oidcRoles: string[] | undefined;
 
       switch (process.env.OIDC_PROVIDER) {
           case OidcProviders.KEYCLOAK: {

--- a/src/modules/auth/passport/oidc-strategy.ts
+++ b/src/modules/auth/passport/oidc-strategy.ts
@@ -81,7 +81,7 @@ passport.use(
               break;
           }
           case 'ENTRA_ID': {
-              oidcRoles = tokenDetails.roles
+              oidcRoles = tokenDetails.roles || [];
               break;
           }
           default: {
@@ -92,7 +92,7 @@ passport.use(
           }
       }
 
-      const securityRoles = parseRoles(oidcRoles!);
+      const securityRoles = parseRoles(oidcRoles);
 
       if (securityRoles.length === 0) {
         req.res?.sendStatus(403);

--- a/src/modules/auth/passport/oidc-strategy.ts
+++ b/src/modules/auth/passport/oidc-strategy.ts
@@ -40,7 +40,7 @@ passport.use(
       );
     }
 
-    const oidcConfigRes = await fetch(process.env.OIDC_CONFIG);
+    const oidcConfigRes = await fetch(process.env.OIDC_CONFIG!);
     let oidcConfig;
 
     try {
@@ -83,9 +83,15 @@ passport.use(
               oidcRoles = tokenDetails.roles
               break;
           }
+          default: {
+              throw new HttpApiException(
+                  HttpStatusCode.InternalServerError,
+                  'Invalid OIDC provider configured.',
+              );
+          }
       }
 
-      const securityRoles = parseRoles(oidcRoles);
+      const securityRoles = parseRoles(oidcRoles!);
 
       if (securityRoles.length === 0) {
         req.res?.sendStatus(403);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "esnext",
     "module": "commonjs",
     "outDir": "dist",
+    "types": ["node"],
 
     /* Strict Type-Checking Options */
     "strict": true,


### PR DESCRIPTION
- Made the OIDC passport strategy a bit more generic
- Added an option for entra id roles paths. These role paths seem not to be the same between different OIDC providers so that is kinda annoying

TODO:
- [x] Test with keycloak
- [x] Test with entra ID (I cannot seem to get a developer account nor an azure environment so Pim needs to test this I think)
- [x] Documentation on how to set up a OIDC provider