### PR TITLE
feat(orders): add support for Hubble ordering system

### DIFF
--- a/src/helpers/security-groups.ts
+++ b/src/helpers/security-groups.ts
@@ -26,6 +26,7 @@ export interface ISecurityGroups {
   spotify: ISecuritySections;
   sudosos: ISecuritySections;
   serverSettings: ISecuritySections;
+  orders: ISecuritySections;
 }
 
 /**
@@ -131,6 +132,10 @@ export const securityGroups = {
   serverSettings: {
     base: allSecurityGroups,
     privileged: [SecurityGroup.ADMIN],
+  },
+  orders: {
+    base: allSecuritySubscriberGroups,
+    privileged: baseSecurityGroups,
   },
 };
 

--- a/src/modules/backoffice/synchronizer.ts
+++ b/src/modules/backoffice/synchronizer.ts
@@ -1,23 +1,19 @@
 import { Namespace } from 'socket.io';
 import { MusicEmitter } from '../events';
 import { BackofficeSyncEmitter } from '../events/backoffice-sync-emitter';
+import EmitterStore from '../events/emitter-store';
 
-interface Emitters {
-  musicEmitter: MusicEmitter;
-  backofficeEmitter: BackofficeSyncEmitter;
-}
-
-export default function initBackofficeSynchronizer(
-  socket: Namespace,
-  { musicEmitter, backofficeEmitter }: Emitters,
-) {
-  musicEmitter.on('beat', (event) => {
+export default function initBackofficeSynchronizer(socket: Namespace, emitterStore: EmitterStore) {
+  emitterStore.musicEmitter.on('beat', (event) => {
     socket.emit('beat', event);
   });
-  musicEmitter.on('change_track', (event) => {
+  emitterStore.musicEmitter.on('change_track', (event) => {
     socket.emit('change_track', event);
   });
-  backofficeEmitter.on('*', (eventName: string, ...args: any[]) => {
+  emitterStore.backofficeSyncEmitter.on('*', (eventName: string, ...args: any[]) => {
     socket.emit(eventName, ...args);
+  });
+  emitterStore.orderEmitter.on('orders', (event) => {
+    socket.emit('orders', event);
   });
 }

--- a/src/modules/events/emitter-store.ts
+++ b/src/modules/events/emitter-store.ts
@@ -1,5 +1,6 @@
 import { BackofficeSyncEmitter } from './backoffice-sync-emitter';
 import { MusicEmitter } from './music-emitter';
+import { OrderEmitter } from './order-emitter';
 
 export default class EmitterStore {
   private static instance: EmitterStore;
@@ -8,9 +9,12 @@ export default class EmitterStore {
 
   public readonly musicEmitter: MusicEmitter;
 
+  public readonly orderEmitter: OrderEmitter;
+
   constructor() {
     this.backofficeSyncEmitter = new BackofficeSyncEmitter();
     this.musicEmitter = new MusicEmitter();
+    this.orderEmitter = new OrderEmitter();
   }
 
   public static getInstance() {

--- a/src/modules/events/order-emitter-events.ts
+++ b/src/modules/events/order-emitter-events.ts
@@ -1,0 +1,5 @@
+import { Order } from '../orders/entities';
+
+export interface ShowOrdersEvent {
+  orders: Order[];
+}

--- a/src/modules/events/order-emitter.ts
+++ b/src/modules/events/order-emitter.ts
@@ -1,0 +1,9 @@
+import { EventEmitter } from 'node:events';
+import { Order } from '../orders/entities';
+import { ShowOrdersEvent } from './order-emitter-events';
+
+export class OrderEmitter extends EventEmitter {
+  showOrders(showOrdersEvent: ShowOrdersEvent): boolean {
+    return super.emit('orders', showOrdersEvent);
+  }
+}

--- a/src/modules/handlers/base-screen-handler.ts
+++ b/src/modules/handlers/base-screen-handler.ts
@@ -4,6 +4,8 @@ import BaseHandler from './base-handler';
 import Screen from '../root/entities/screen';
 import { TrackChangeEvent } from '../events/music-emitter-events';
 import { SocketioNamespaces } from '../../socketio-namespaces';
+import { ShowOrdersEvent } from '../events/order-emitter-events';
+import { FeatureEnabled } from '../server-settings';
 
 export default abstract class BaseScreenHandler extends BaseHandler<Screen> {
   constructor(private socket: Namespace) {
@@ -11,6 +13,11 @@ export default abstract class BaseScreenHandler extends BaseHandler<Screen> {
   }
 
   abstract changeTrack(event: TrackChangeEvent[]): void;
+
+  @FeatureEnabled('Orders')
+  public showOrders(event: ShowOrdersEvent): void {
+    this.sendEvent('orders', event);
+  }
 
   protected sendEvent(eventName: string, ...args: EventParams<any, any>) {
     this.entities.forEach((e) => {

--- a/src/modules/modes/mode-manager.ts
+++ b/src/modules/modes/mode-manager.ts
@@ -1,13 +1,12 @@
 import BaseMode from './base-mode';
 import { MusicEmitter } from '../events';
 import { BackofficeSyncEmitter } from '../events/backoffice-sync-emitter';
+import EmitterStore from '../events/emitter-store';
 
 export default class ModeManager {
   private static instance: ModeManager;
 
-  private _musicEmitter: MusicEmitter;
-
-  private _backofficeSyncEmitter: BackofficeSyncEmitter;
+  private _emitterStore: EmitterStore;
 
   private modes: Map<typeof BaseMode, BaseMode<any, any, any> | undefined> = new Map();
 
@@ -20,10 +19,9 @@ export default class ModeManager {
     return this.instance;
   }
 
-  public init(musicEmitter: MusicEmitter, backofficeEmitter: BackofficeSyncEmitter) {
+  public init(emitterStore: EmitterStore) {
     if (this.initialized) throw new Error('ModeManager already initialized');
-    this._musicEmitter = musicEmitter;
-    this._backofficeSyncEmitter = backofficeEmitter;
+    this._emitterStore = emitterStore;
     this.initialized = true;
   }
 
@@ -36,7 +34,7 @@ export default class ModeManager {
     if (this.modes.has(modeClass)) this.disableMode(modeClass);
 
     this.modes.set(modeClass, mode);
-    this._backofficeSyncEmitter.emit(`mode_${name}_update`);
+    this._emitterStore.backofficeSyncEmitter.emit(`mode_${name}_update`);
   }
 
   public getMode(modeClass: typeof BaseMode<any, any, any>) {
@@ -46,16 +44,16 @@ export default class ModeManager {
   public disableMode(modeClass: typeof BaseMode<any, any, any>, name?: string) {
     const instance = this.modes.get(modeClass);
     if (instance) instance.destroy();
-    if (name) this._backofficeSyncEmitter.emit(`mode_${name}_update`);
+    if (name) this._emitterStore.backofficeSyncEmitter.emit(`mode_${name}_update`);
     return this.modes.delete(modeClass);
   }
 
   public get musicEmitter() {
-    return this._musicEmitter;
+    return this._emitterStore.musicEmitter;
   }
 
   public get backofficeSyncEmitter() {
-    return this._backofficeSyncEmitter;
+    return this._emitterStore.backofficeSyncEmitter;
   }
 
   /**

--- a/src/modules/orders/entities/index.ts
+++ b/src/modules/orders/entities/index.ts
@@ -1,0 +1,1 @@
+export { default as Order } from './order';

--- a/src/modules/orders/entities/order.ts
+++ b/src/modules/orders/entities/order.ts
@@ -1,0 +1,5 @@
+export default interface Order {
+  number: number;
+  startTime: Date;
+  timeoutSeconds: number;
+}

--- a/src/modules/orders/index.ts
+++ b/src/modules/orders/index.ts
@@ -1,0 +1,1 @@
+export { default as OrderManager } from './order-manager';

--- a/src/modules/orders/order-controller.ts
+++ b/src/modules/orders/order-controller.ts
@@ -4,6 +4,7 @@ import { Body, Delete, Get, Post, Route, Security, Tags } from 'tsoa';
 import { SecurityNames } from '../../helpers/security';
 import { securityGroups } from '../../helpers/security-groups';
 import OrderStore from './order-store';
+import OrderManager from './order-manager';
 
 interface OrderRequest {
   orderNumber: number;
@@ -18,24 +19,24 @@ export class OrderController extends Controller {
   @Get('')
   @Response<string>(409, 'Endpoint is disabled in the server settings')
   public async getAllOrders() {
-    return OrderStore.getInstance().orders;
+    return OrderManager.getInstance().getOrders();
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.orders.privileged)
   @Post('')
   @Response<string>(409, 'Endpoint is disabled in the server settings')
   public async addOrder(@Body() orderRequest: OrderRequest) {
-    const store = OrderStore.getInstance();
-    await store.addOrder(orderRequest.orderNumber, orderRequest.timeoutSeconds);
-    return store.orders;
+    const manager = OrderManager.getInstance();
+    await manager.addOrder(orderRequest.orderNumber, orderRequest.timeoutSeconds);
+    return manager.getOrders();
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.orders.privileged)
   @Delete('{orderNumber}')
   @Response<string>(409, 'Endpoint is disabled in the server settings')
   public async removeOrder(orderNumber: number) {
-    const store = OrderStore.getInstance();
-    await store.removeOrder(orderNumber);
-    return store.orders;
+    const manager = OrderManager.getInstance();
+    await manager.removeOrder(orderNumber);
+    return manager.getOrders();
   }
 }

--- a/src/modules/orders/order-controller.ts
+++ b/src/modules/orders/order-controller.ts
@@ -62,6 +62,7 @@ export class OrderController extends Controller {
         throw new Error(`Failed to fetch public key: ${response.statusText}`);
       }
       this.webhookPublicKey = await response.text();
+      this.webhookKeyLastUpdate = new Date();
     }
 
     // Create a verifier

--- a/src/modules/orders/order-controller.ts
+++ b/src/modules/orders/order-controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Response } from '@tsoa/runtime';
+import { FeatureEnabled } from '../server-settings';
+import { Body, Delete, Get, Post, Route, Security, Tags } from 'tsoa';
+import { SecurityNames } from '../../helpers/security';
+import { securityGroups } from '../../helpers/security-groups';
+import OrderStore from './order-store';
+
+interface OrderRequest {
+  orderNumber: number;
+  timeoutSeconds?: number;
+}
+
+@Tags('Orders')
+@Route('/orders')
+@FeatureEnabled('Orders')
+export class OrderController extends Controller {
+  @Security(SecurityNames.LOCAL, securityGroups.orders.base)
+  @Get('')
+  @Response<string>(409, 'Endpoint is disabled in the server settings')
+  public async getAllOrders() {
+    return OrderStore.getInstance().orders;
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.orders.privileged)
+  @Post('')
+  @Response<string>(409, 'Endpoint is disabled in the server settings')
+  public async addOrder(@Body() orderRequest: OrderRequest) {
+    const store = OrderStore.getInstance();
+    await store.addOrder(orderRequest.orderNumber, orderRequest.timeoutSeconds);
+    return store.orders;
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.orders.privileged)
+  @Delete('{orderNumber}')
+  @Response<string>(409, 'Endpoint is disabled in the server settings')
+  public async removeOrder(orderNumber: number) {
+    const store = OrderStore.getInstance();
+    await store.removeOrder(orderNumber);
+    return store.orders;
+  }
+}

--- a/src/modules/orders/order-controller.ts
+++ b/src/modules/orders/order-controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Response } from '@tsoa/runtime';
-import { FeatureEnabled } from '../server-settings';
-import { Body, Delete, Get, Post, Route, Security, Tags } from 'tsoa';
+import { Controller, Header, Response, TsoaResponse } from '@tsoa/runtime';
+import { createVerify } from 'crypto';
+import { FeatureEnabled, ServerSettingsStore } from '../server-settings';
+import { Body, Delete, Get, Post, Res, Route, Security, Tags } from 'tsoa';
 import { SecurityNames } from '../../helpers/security';
 import { securityGroups } from '../../helpers/security-groups';
-import OrderStore from './order-store';
 import OrderManager from './order-manager';
+import { OrderSettings } from './order-settings';
 
 interface OrderRequest {
   orderNumber: number;
@@ -15,6 +16,10 @@ interface OrderRequest {
 @Route('/orders')
 @FeatureEnabled('Orders')
 export class OrderController extends Controller {
+  private webhookPublicKey: string;
+
+  private webhookKeyLastUpdate = new Date();
+
   @Security(SecurityNames.LOCAL, securityGroups.orders.base)
   @Get('')
   @Response<string>(409, 'Endpoint is disabled in the server settings')
@@ -26,6 +31,53 @@ export class OrderController extends Controller {
   @Post('')
   @Response<string>(409, 'Endpoint is disabled in the server settings')
   public async addOrder(@Body() orderRequest: OrderRequest) {
+    const manager = OrderManager.getInstance();
+    await manager.addOrder(orderRequest.orderNumber, orderRequest.timeoutSeconds);
+    return manager.getOrders();
+  }
+
+  @Post('webhook')
+  @FeatureEnabled('Orders.WebhookPublicKeyURL')
+  @Response<string>(409, 'Endpoint is disabled in the server settings')
+  public async addOrderWebhook(
+    @Body() orderRequest: OrderRequest,
+    @Header('X-Signature') signature: string,
+    @Res() invalidSignatureResponse: TsoaResponse<400, { message: string }>,
+  ) {
+    const settingsStore = ServerSettingsStore.getInstance();
+    const expiryTimeSeconds = settingsStore.getSetting(
+      'Orders.DefaultTimeoutSeconds',
+    ) as OrderSettings['Orders.DefaultTimeoutSeconds'];
+
+    if (
+      !this.webhookPublicKey ||
+      new Date().getTime() - this.webhookKeyLastUpdate.getTime() > 1000 * expiryTimeSeconds
+    ) {
+      const webhookKeyUrl = settingsStore.getSetting(
+        'Orders.WebhookPublicKeyURL',
+      ) as OrderSettings['Orders.WebhookPublicKeyURL'];
+
+      const response = await fetch(webhookKeyUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch public key: ${response.statusText}`);
+      }
+      this.webhookPublicKey = await response.text();
+    }
+
+    // Create a verifier
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(JSON.stringify(orderRequest));
+    verifier.end();
+
+    // Decode the Base64 signature
+    const decodedSignature = Buffer.from(signature, 'base64');
+
+    // Verify the signature
+    const isValid = verifier.verify(this.webhookPublicKey, decodedSignature);
+    if (!isValid) {
+      return invalidSignatureResponse(400, { message: 'Signature invalid' });
+    }
+
     const manager = OrderManager.getInstance();
     await manager.addOrder(orderRequest.orderNumber, orderRequest.timeoutSeconds);
     return manager.getOrders();

--- a/src/modules/orders/order-manager.ts
+++ b/src/modules/orders/order-manager.ts
@@ -1,0 +1,43 @@
+import { OrderEmitter } from '../events/order-emitter';
+import { FeatureEnabled } from '../server-settings';
+import OrderStore from './order-store';
+
+@FeatureEnabled('Orders')
+export default class OrderManager {
+  private static instance: OrderManager;
+
+  private orderStore: OrderStore;
+
+  private orderEmitter: OrderEmitter;
+
+  public static getInstance(): OrderManager {
+    if (!this.instance) {
+      this.instance = new OrderManager();
+    }
+    return this.instance;
+  }
+
+  public init(orderEmitter: OrderEmitter) {
+    if (this.orderEmitter) throw new Error('OrderEmitter is already initialized');
+    this.orderEmitter = orderEmitter;
+    this.orderStore = new OrderStore();
+  }
+
+  public async getOrders() {
+    return this.orderStore.orders;
+  }
+
+  public async addOrder(orderNumber: number, timeoutSeconds?: number) {
+    await this.orderStore.addOrder(orderNumber, timeoutSeconds);
+    const orders = await this.orderStore.orders;
+    this.orderEmitter.showOrders({ orders });
+    return orders;
+  }
+
+  public async removeOrder(orderNumber: number) {
+    await this.orderStore.removeOrder(orderNumber);
+    const orders = await this.orderStore.orders;
+    this.orderEmitter.showOrders({ orders });
+    return orders;
+  }
+}

--- a/src/modules/orders/order-settings.ts
+++ b/src/modules/orders/order-settings.ts
@@ -1,0 +1,9 @@
+export interface OrderSettings {
+  Orders: boolean;
+  'Orders.DefaultTimeoutSeconds': number;
+}
+
+export const OrderSettingsDefault: OrderSettings = {
+  Orders: true,
+  'Orders.DefaultTimeoutSeconds': 120,
+};

--- a/src/modules/orders/order-settings.ts
+++ b/src/modules/orders/order-settings.ts
@@ -1,9 +1,13 @@
 export interface OrderSettings {
   Orders: boolean;
   'Orders.DefaultTimeoutSeconds': number;
+  'Orders.WebhookPublicKeyURL': string;
+  'Orders.WebhookPublicKeyExpirySeconds': number;
 }
 
 export const OrderSettingsDefault: OrderSettings = {
   Orders: true,
   'Orders.DefaultTimeoutSeconds': 120,
+  'Orders.WebhookPublicKeyURL': '',
+  'Orders.WebhookPublicKeyExpirySeconds': 60 * 60,
 };

--- a/src/modules/orders/order-store.ts
+++ b/src/modules/orders/order-store.ts
@@ -1,11 +1,6 @@
 import { FeatureEnabled, ServerSettingsStore } from '../server-settings';
 import { ISettings } from '../server-settings/server-setting';
-
-export type Order = {
-  number: number;
-  startTime: Date;
-  timeoutSeconds: number;
-};
+import { Order } from './entities';
 
 /**
  * In memory store of all orders that should be propagated using Aurora.
@@ -15,18 +10,9 @@ export type Order = {
  */
 @FeatureEnabled('Orders')
 export default class OrderStore {
-  private static instance: OrderStore;
-
   private settingsStore: ServerSettingsStore;
 
   private _orders: Order[] = [];
-
-  public static getInstance() {
-    if (!this.instance) {
-      this.instance = new OrderStore();
-    }
-    return this.instance;
-  }
 
   constructor() {
     this.settingsStore = ServerSettingsStore.getInstance();

--- a/src/modules/orders/order-store.ts
+++ b/src/modules/orders/order-store.ts
@@ -43,16 +43,24 @@ export default class OrderStore {
    * @param timeoutSeconds Time after which the order should automatically be hidden
    */
   public async addOrder(orderNumber: number, timeoutSeconds?: number): Promise<void> {
-    const order: Order = {
-      number: orderNumber,
-      startTime: new Date(),
-      timeoutSeconds:
-        timeoutSeconds ??
-        (this.settingsStore.getSetting(
-          'Orders.DefaultTimeoutSeconds',
-        ) as ISettings['Orders.DefaultTimeoutSeconds']),
-    };
-    this._orders.push(order);
+    const index = this._orders.findIndex((o) => o.number === orderNumber);
+    const timeout =
+      timeoutSeconds ??
+      (this.settingsStore.getSetting(
+        'Orders.DefaultTimeoutSeconds',
+      ) as ISettings['Orders.DefaultTimeoutSeconds']);
+
+    if (index >= 0) {
+      this._orders[index].startTime = new Date();
+      this._orders[index].timeoutSeconds = timeout;
+    } else {
+      const order: Order = {
+        number: orderNumber,
+        startTime: new Date(),
+        timeoutSeconds: timeout,
+      };
+      this._orders.push(order);
+    }
 
     await this.removeExpiredOrders();
   }

--- a/src/modules/server-settings/feature-enabled.ts
+++ b/src/modules/server-settings/feature-enabled.ts
@@ -29,8 +29,8 @@ export default function FeatureEnabled(setting: keyof ISettings): ClassDecorator
       return;
     }
 
-    const value = store.getSetting(setting);
-    if (!value) {
+    const enabled = featureFlagManager.flagIsEnabled(setting);
+    if (!enabled) {
       res.status(409).send(`Endpoint is disabled by setting "${setting}".`);
       return;
     }
@@ -69,8 +69,8 @@ export default function FeatureEnabled(setting: keyof ISettings): ClassDecorator
         constructor(...constructorArgs: any[]) {
           store.throwIfNotInitialized();
 
-          const value = store.getSetting(setting);
-          if (!value) {
+          const enabled = featureFlagManager.flagIsEnabled(setting);
+          if (!enabled) {
             throw new Error(`Class "${constr.name}" is disabled by setting "${setting}"`);
           }
 
@@ -88,8 +88,8 @@ export default function FeatureEnabled(setting: keyof ISettings): ClassDecorator
       const store = ServerSettingsStore.getInstance();
       store.throwIfNotInitialized();
 
-      const value = store.getSetting(setting);
-      if (!value) {
+      const enabled = featureFlagManager.flagIsEnabled(setting);
+      if (!enabled) {
         throw new Error(`Method "${propertyKey.toString()}" is disabled by setting "${setting}"`);
       }
       return originalMethod.apply(this, methodArgs);

--- a/src/modules/server-settings/feature-flag-manager.ts
+++ b/src/modules/server-settings/feature-flag-manager.ts
@@ -6,10 +6,13 @@ type HandlerClass = new (...args: any[]) => BaseHandler<any>;
 
 /**
  * Being an extension of the ServerSettingsStore, the Feature Flag Manager is responsible for
- * - as the name suggests - all feature flags present in the system. It does not say whether
- * a flag is enabled or not, but it does keep track of all other operations regarding those flags.
+ * - as the name suggests - all feature flags present in the system and whether they are
+ * enabled or not.
  */
 export default class FeatureFlagManager {
+  // Class has to be a singleton, because the @FeatureEnabled() decorator
+  // uses this class as storage to keep track which settings are being
+  // used as feature flags.
   private static instance: FeatureFlagManager;
 
   private featureFlags = new Set<keyof ISettings>();
@@ -36,6 +39,16 @@ export default class FeatureFlagManager {
    */
   public registerFeatureFlag(key: keyof ISettings) {
     this.featureFlags.add(key);
+  }
+
+  /**
+   * Returns whether a feature flag resolves to true (and thus is enabled)
+   * @param key
+   */
+  public flagIsEnabled(key: keyof ISettings): boolean {
+    // For sanity, register the key as a feature flag
+    this.registerFeatureFlag(key);
+    return !!this.serverSettingsStore.getSetting(key);
   }
 
   /**

--- a/src/modules/server-settings/server-setting.ts
+++ b/src/modules/server-settings/server-setting.ts
@@ -6,13 +6,19 @@ import {
   ScreenHandlerSettings,
   ScreenHandlerSettingsDefaults,
 } from '../handlers/screen/screen-handler-settings';
+import { OrderSettings, OrderSettingsDefault } from '../orders/order-settings';
 
-export interface ISettings extends SudoSOSSettings, ModeSettings, ScreenHandlerSettings {}
+export interface ISettings
+  extends SudoSOSSettings,
+    ModeSettings,
+    ScreenHandlerSettings,
+    OrderSettings {}
 
 export const SettingsDefaults: ISettings = {
   ...SudoSOSSettingsDefault,
   ...ModeSettingsDefaults,
   ...ScreenHandlerSettingsDefaults,
+  ...OrderSettingsDefault,
 };
 
 /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This PR adds a new module that implements the ordering system for Hubble. It's goal is to receive order numbers and show them for a certain amount of time on all screen clients. New orders are sent to Aurora using an HTTP endpoint. Then, every time an order is added or manually removed, Aurora sends a SocketIO message to all screen clients with the complete list of all order numbers. Each order number also includes the creation time and after how many seconds the order should be hidden. Note that Aurora Core does not send a message when an order number is expired: the screen clients should hide these themselves after their expiry (to save network resources and server side complexity).

The list of orders is not persistent: it is stored in memory.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_