### PR TITLE
fix(spotify): remove deprecated audio analysis

### DIFF
--- a/src/modules/events/music-emitter-events.ts
+++ b/src/modules/events/music-emitter-events.ts
@@ -7,18 +7,6 @@ export interface BeatEvent {
   tatum?: Tatum;
 }
 
-/**
- * To understand the meaning of these variables, please see
- * https://developer.spotify.com/documentation/web-api/reference/get-audio-features
- */
-export interface TrackPropertiesEvent {
-  bpm: number;
-  danceability: number;
-  energy: number;
-  loudness: number;
-  valence: number;
-}
-
 export interface TrackChangeEvent {
   title: string;
   artists: string[];

--- a/src/modules/handlers/base-lights-handler.ts
+++ b/src/modules/handlers/base-lights-handler.ts
@@ -1,18 +1,7 @@
 import BaseHandler from './base-handler';
 import { LightsGroup } from '../lights/entities';
-import { TrackPropertiesEvent } from '../events/music-emitter-events';
 
 export default abstract class BaseLightsHandler extends BaseHandler<LightsGroup> {
-  protected trackFeatures?: TrackPropertiesEvent;
-
-  /**
-   * Set the bpm of the current song. Zero (0) if no bpm
-   * @param features
-   */
-  public setFeatures(features: TrackPropertiesEvent): void {
-    this.trackFeatures = features;
-  }
-
   /**
    * Second event loop to calculate the current DMX values.
    * Always runs at a predefined frequency, defined in `LIGHTS_TICK_INTERVAL` (in Hz).

--- a/src/modules/handlers/lights/random-effects-handler.ts
+++ b/src/modules/handlers/lights/random-effects-handler.ts
@@ -35,11 +35,7 @@ export default class RandomEffectsHandler extends EffectsHandler {
       if (random < 0.8) {
         this.groupColorEffects.set(
           entity,
-          new BeatFadeOut(
-            entity,
-            { colors: this.colors, enableFade: false, nrBlacks: 1 },
-            this.trackFeatures,
-          ),
+          new BeatFadeOut(entity, { colors: this.colors, enableFade: false, nrBlacks: 1 }),
         );
       } else if (random < 0.9) {
         this.groupColorEffects.set(entity, new Wave(entity, { colors: this.colors }));

--- a/src/modules/handlers/lights/set-effects-handler.ts
+++ b/src/modules/handlers/lights/set-effects-handler.ts
@@ -20,7 +20,7 @@ export default class SetEffectsHandler extends EffectsHandler {
     this.destroyEffect(effectsMap.get(lightsGroup));
     effectsMap.set(
       lightsGroup,
-      effects.map((e) => e(lightsGroup, this.trackFeatures)),
+      effects.map((e) => e(lightsGroup)),
     );
   }
 

--- a/src/modules/lights/effects/color/beat-fade-out.ts
+++ b/src/modules/lights/effects/color/beat-fade-out.ts
@@ -4,14 +4,13 @@ import LightsEffect, {
   BaseLightsEffectProps,
   LightsEffectBuilder,
 } from '../lights-effect';
-import { BeatEvent, TrackPropertiesEvent } from '../../../events/music-emitter-events';
+import { BeatEvent } from '../../../events/music-emitter-events';
 import {
   LightsGroup,
   LightsGroupMovingHeadRgbs,
   LightsGroupMovingHeadWheels,
   LightsGroupPars,
 } from '../../entities';
-import { RgbColor } from '../../color-definitions';
 import { ColorEffects } from './color-effects';
 import {
   EffectProgressionBeatStrategy,
@@ -19,7 +18,6 @@ import {
 } from '../progression-strategies';
 import EffectProgressionStrategy from '../progression-strategies/effect-progression-strategy';
 import LightsGroupFixture from '../../entities/lights-group-fixture';
-import { LightsEffectDirection, LightsEffectPattern } from '../lights-effect-pattern';
 import EffectProgressionMapFactory from '../progression-strategies/mappers/effect-progression-map-factory';
 
 export interface BeatFadeOutProps extends BaseLightsEffectProps, BaseLightsEffectProgressionProps {
@@ -57,7 +55,7 @@ export default class BeatFadeOut extends LightsEffect<BeatFadeOutProps> {
 
   private beatLength: number = 1; // in ms;
 
-  constructor(lightsGroup: LightsGroup, props: BeatFadeOutProps, features?: TrackPropertiesEvent) {
+  constructor(lightsGroup: LightsGroup, props: BeatFadeOutProps) {
     const nrSteps = props.colors.length + (props.nrBlacks ?? 0);
 
     const progressionMapperStrategy = new EffectProgressionMapFactory(lightsGroup).getMapper(
@@ -74,7 +72,7 @@ export default class BeatFadeOut extends LightsEffect<BeatFadeOutProps> {
       );
     }
 
-    super(lightsGroup, progressionStrategy, progressionMapperStrategy, props.direction, features);
+    super(lightsGroup, progressionStrategy, progressionMapperStrategy, props.direction);
 
     this.nrSteps = nrSteps;
     this.props = props;
@@ -91,8 +89,7 @@ export default class BeatFadeOut extends LightsEffect<BeatFadeOutProps> {
    * @param props
    */
   public static build(props: BeatFadeOutProps): LightsEffectBuilder<BeatFadeOutProps, BeatFadeOut> {
-    return (lightsGroup: LightsGroup, features?: TrackPropertiesEvent) =>
-      new BeatFadeOut(lightsGroup, props, features);
+    return (lightsGroup: LightsGroup) => new BeatFadeOut(lightsGroup, props);
   }
 
   destroy(): void {}

--- a/src/modules/lights/effects/color/fire.ts
+++ b/src/modules/lights/effects/color/fire.ts
@@ -1,5 +1,4 @@
 import LightsEffect, { BaseLightsEffectCreateParams, LightsEffectBuilder } from '../lights-effect';
-import { TrackPropertiesEvent } from '../../../events/music-emitter-events';
 import { LightsGroup } from '../../entities';
 
 interface FireProps {}
@@ -10,13 +9,12 @@ export type FireCreateParams = BaseLightsEffectCreateParams & {
 };
 
 export default class Fire extends LightsEffect<FireProps> {
-  constructor(lightsGroup: LightsGroup, props?: FireProps, features?: TrackPropertiesEvent) {
-    super(lightsGroup, undefined, undefined, undefined, features);
+  constructor(lightsGroup: LightsGroup, props?: FireProps) {
+    super(lightsGroup);
   }
 
   public static build(props?: FireProps): LightsEffectBuilder<FireProps, Fire> {
-    return (lightsGroup: LightsGroup, features?: TrackPropertiesEvent) =>
-      new Fire(lightsGroup, props, features);
+    return (lightsGroup: LightsGroup) => new Fire(lightsGroup, props);
   }
 
   beat(): void {}

--- a/src/modules/lights/effects/color/sparkle.ts
+++ b/src/modules/lights/effects/color/sparkle.ts
@@ -3,9 +3,7 @@ import LightsEffect, {
   BaseLightsEffectProps,
   LightsEffectBuilder,
 } from '../lights-effect';
-import { RgbColor } from '../../color-definitions';
 import { LightsGroup } from '../../entities';
-import { TrackPropertiesEvent } from '../../../events/music-emitter-events';
 import { ColorEffects } from './color-effects';
 
 export interface SparkleProps extends BaseLightsEffectProps {
@@ -51,10 +49,9 @@ export default class Sparkle extends LightsEffect<SparkleProps> {
   /**
    * @param lightsGroup The group of lights this effect will be applied to
    * @param props
-   * @param features
    */
-  constructor(lightsGroup: LightsGroup, props: SparkleProps, features?: TrackPropertiesEvent) {
-    super(lightsGroup, undefined, undefined, undefined, features);
+  constructor(lightsGroup: LightsGroup, props: SparkleProps) {
+    super(lightsGroup);
 
     const nrFixtures = lightsGroup.pars.length + lightsGroup.movingHeadRgbs.length;
     this.beats = new Array(nrFixtures).fill(new Date(0));
@@ -64,8 +61,7 @@ export default class Sparkle extends LightsEffect<SparkleProps> {
   }
 
   public static build(props: SparkleProps): LightsEffectBuilder<SparkleProps, Sparkle> {
-    return (lightsGroup: LightsGroup, features?: TrackPropertiesEvent) =>
-      new Sparkle(lightsGroup, props, features);
+    return (lightsGroup: LightsGroup) => new Sparkle(lightsGroup, props);
   }
 
   /**

--- a/src/modules/lights/effects/color/static-color.ts
+++ b/src/modules/lights/effects/color/static-color.ts
@@ -1,8 +1,6 @@
 import LightsEffect, { BaseLightsEffectCreateParams, LightsEffectBuilder } from '../lights-effect';
-
 import { LightsGroup } from '../../entities';
 import { RgbColor } from '../../color-definitions';
-import { TrackPropertiesEvent } from '../../../events/music-emitter-events';
 import { ColorEffects } from './color-effects';
 
 export interface StaticColorProps {
@@ -57,8 +55,8 @@ export default class StaticColor extends LightsEffect<StaticColorProps> {
 
   private cycleStartTick: Date = new Date();
 
-  constructor(lightsGroup: LightsGroup, props: StaticColorProps, features?: TrackPropertiesEvent) {
-    super(lightsGroup, undefined, undefined, undefined, features);
+  constructor(lightsGroup: LightsGroup, props: StaticColorProps) {
+    super(lightsGroup);
     this.props = props;
 
     this.lightsGroup.fixtures.forEach((f) => {
@@ -76,7 +74,7 @@ export default class StaticColor extends LightsEffect<StaticColorProps> {
   }
 
   public static build(props: StaticColorProps): LightsEffectBuilder<StaticColorProps, StaticColor> {
-    return (lightsGroup, features) => new StaticColor(lightsGroup, props, features);
+    return (lightsGroup) => new StaticColor(lightsGroup, props);
   }
 
   beat(): void {

--- a/src/modules/lights/effects/color/strobe.ts
+++ b/src/modules/lights/effects/color/strobe.ts
@@ -1,6 +1,5 @@
 import LightsEffect, { BaseLightsEffectCreateParams, LightsEffectBuilder } from '../lights-effect';
 import { LightsGroup } from '../../entities';
-import { TrackPropertiesEvent } from '../../../events/music-emitter-events';
 import { ColorEffects } from './color-effects';
 
 export interface StrobeProps {
@@ -18,8 +17,8 @@ export type StrobeCreateParams = BaseLightsEffectCreateParams & {
 };
 
 export default class Strobe extends LightsEffect<StrobeProps> {
-  constructor(lightsGroup: LightsGroup, props: StrobeProps, features?: TrackPropertiesEvent) {
-    super(lightsGroup, undefined, undefined, undefined, features);
+  constructor(lightsGroup: LightsGroup, props: StrobeProps) {
+    super(lightsGroup);
     this.props = props;
 
     this.lightsGroup.pars.forEach((p) => {
@@ -46,6 +45,6 @@ export default class Strobe extends LightsEffect<StrobeProps> {
   }
 
   public static build(props: StrobeProps): LightsEffectBuilder<StrobeProps, Strobe> {
-    return (lightsGroup, features) => new Strobe(lightsGroup, props, features);
+    return (lightsGroup) => new Strobe(lightsGroup, props);
   }
 }

--- a/src/modules/lights/effects/lights-effect.ts
+++ b/src/modules/lights/effects/lights-effect.ts
@@ -1,4 +1,4 @@
-import { BeatEvent, TrackPropertiesEvent } from '../../events/music-emitter-events';
+import { BeatEvent } from '../../events/music-emitter-events';
 import { LightsGroup } from '../entities';
 import EffectProgressionStrategy from './progression-strategies/effect-progression-strategy';
 import LightsGroupFixture from '../entities/lights-group-fixture';
@@ -9,7 +9,6 @@ import { RgbColor } from '../color-definitions';
 
 export type LightsEffectBuilder<P = {}, T extends LightsEffect<P> = LightsEffect<P>> = (
   lightsGroup: LightsGroup,
-  features?: TrackPropertiesEvent,
 ) => T;
 
 export interface BaseLightsEffectProps {
@@ -43,7 +42,6 @@ export default abstract class LightsEffect<P = {}> {
     private readonly progressionStrategy?: EffectProgressionStrategy,
     progressionMapperStrategy?: EffectProgressionMapStrategy,
     private patternDirection = LightsEffectDirection.FORWARDS,
-    protected features?: TrackPropertiesEvent,
   ) {
     if (!progressionMapperStrategy) {
       this.progressionMapperStrategy = new EffectProgressionMapFactory(this.lightsGroup).getMapper(

--- a/src/modules/root/lights-controller-manager.ts
+++ b/src/modules/root/lights-controller-manager.ts
@@ -9,7 +9,6 @@ import {
   LightsGroup,
 } from '../lights/entities';
 import HandlerManager from './handler-manager';
-import { TrackPropertiesEvent } from '../events/music-emitter-events';
 import { SocketioNamespaces } from '../../socketio-namespaces';
 
 const DMX_VALUES_LENGTH = 512;
@@ -50,8 +49,6 @@ export default class LightsControllerManager {
       this.lightsControllersValues.set(c.id, this.constructNewValuesArray());
     });
 
-    musicEmitter.on('features', this.setTrackFeatures.bind(this));
-
     // Tick rate (currently 35Hz)
     setInterval(this.tick.bind(this), Number(process.env.LIGHTS_TICK_INTERVAL) ?? 29);
   }
@@ -88,10 +85,6 @@ export default class LightsControllerManager {
 
   private get lightsHandlers() {
     return this.handlerManager.getHandlers(LightsGroup) as BaseLightsHandler[];
-  }
-
-  private setTrackFeatures(event: TrackPropertiesEvent) {
-    this.lightsHandlers.forEach((h) => h.setFeatures(event));
   }
 
   /**

--- a/src/modules/spotify/spotify-track-handler.ts
+++ b/src/modules/spotify/spotify-track-handler.ts
@@ -1,7 +1,7 @@
-import { AudioAnalysis, AudioFeatures, PlaybackState, Track } from '@fostertheweb/spotify-web-sdk';
+import { PlaybackState, Track } from '@fostertheweb/spotify-web-sdk';
 import SpotifyApiHandler from './spotify-api-handler';
 import { MusicEmitter } from '../events';
-import { BeatEvent, TrackChangeEvent, TrackPropertiesEvent } from '../events/music-emitter-events';
+import { TrackChangeEvent } from '../events/music-emitter-events';
 import logger from '../../logger';
 
 export default class SpotifyTrackHandler {
@@ -18,24 +18,12 @@ export default class SpotifyTrackHandler {
   /** Currently playing state. Can be defined if not playing anything */
   private playState: PlaybackState | undefined;
 
-  private currentlyPlayingFeatures: AudioFeatures | undefined;
-
-  private currentlyPlayingAnalysis: AudioAnalysis | undefined;
-
-  private beatEvents: {
-    event: BeatEvent;
-    timeout: NodeJS.Timeout;
-  }[];
-
   public musicEmitter: MusicEmitter;
-
-  private ping = false;
 
   private constructor() {
     this.api = SpotifyApiHandler.getInstance();
     setInterval(this.syncLoop.bind(this), 5000);
     this.syncLoop().then(() => {});
-    this.beatEvents = [];
   }
 
   public static getInstance() {
@@ -89,17 +77,6 @@ export default class SpotifyTrackHandler {
     }
   }
 
-  /**
-   * Stop the beat events and delete them
-   * @private
-   */
-  private stopBeatEvents() {
-    this.beatEvents.forEach((e) => {
-      clearTimeout(e.timeout);
-    });
-    this.beatEvents = [];
-  }
-
   private setNextTrackEvent(state: PlaybackState): void {
     if (!state.is_playing) return;
     if (this.syncLoopTimer) {
@@ -111,43 +88,6 @@ export default class SpotifyTrackHandler {
       this.syncLoop.bind(this),
       state.item.duration_ms - state.progress_ms + 10,
     );
-  }
-
-  private setBeatEvents(track?: AudioAnalysis) {
-    this.stopBeatEvents();
-
-    const progress = this.playState?.progress_ms || 0;
-
-    this.beatEvents = track
-      ? track.beats
-          .filter((b) => b.start * 1000 >= progress)
-          .map((beat) => {
-            const segment = track.segments.find(
-              (s) => s.start <= beat.start && s.start + s.duration >= beat.start,
-            );
-            const section = track.sections.find(
-              (s) => s.start <= beat.start && s.start + s.duration >= beat.start,
-            );
-            const tatum = track.tatums.find(
-              (s) => s.start <= beat.start && s.start + s.duration >= beat.start,
-            );
-
-            const beatEvent = {
-              beat,
-              segment,
-              section,
-              tatum,
-            };
-            const timeout = setTimeout(
-              this.syncBeat.bind(this, beatEvent),
-              beat.start * 1000 - progress,
-            );
-            return {
-              event: beatEvent,
-              timeout,
-            };
-          })
-      : [];
   }
 
   /**
@@ -169,10 +109,6 @@ export default class SpotifyTrackHandler {
           this.playState.item?.id !== state.item?.id ||
           (!this.playState.is_playing && state.is_playing))
       ) {
-        this.currentlyPlayingFeatures = await this.api.client.tracks.audioFeatures(state.item.id);
-        this.currentlyPlayingAnalysis = await this.api.client.tracks.audioAnalysis(state.item.id);
-
-        this.emitTrackFeatures(this.currentlyPlayingFeatures);
         this.setNextTrackEvent(state);
 
         const item = state.item as Track;
@@ -186,55 +122,13 @@ export default class SpotifyTrackHandler {
       }
 
       if ((!state || !state.is_playing) && this.playState && this.playState.is_playing) {
-        this.stopBeatEvents();
-        this.currentlyPlayingFeatures = undefined;
-        this.currentlyPlayingAnalysis = undefined;
         this.musicEmitter.emitSpotify('stop');
         logger.info('Spotify paused/stopped');
       }
 
       this.playState = state;
-
-      this.setBeatEvents(this.currentlyPlayingAnalysis);
     } catch (e) {
       logger.fatal(e);
     }
-  }
-
-  /**
-   * Event loop that is called at every beat of the currently playing track
-   * @private
-   */
-  private async syncBeat(event: BeatEvent) {
-    if (!this.playState || !this.playState.is_playing) return;
-
-    if (process.env.LOG_AUDIO_BEATS === 'true') {
-      let beat = '';
-
-      if (this.ping) beat += 'beat:   . ';
-      if (!this.ping) beat += 'beat:  .  ';
-      this.ping = !this.ping;
-
-      beat += `: ${event.beat.start} (${event.beat.confidence}) - ${event.section?.start} - ${event.section?.loudness}`;
-      logger.info(beat);
-    }
-
-    this.musicEmitter.emitSpotify('beat', event);
-  }
-
-  /**
-   * Send the features of the currently playing track to all handlers
-   * @param features
-   * @private
-   */
-  private emitTrackFeatures(features: AudioFeatures) {
-    const event: TrackPropertiesEvent = {
-      bpm: features.tempo,
-      danceability: features.danceability,
-      energy: features.energy,
-      loudness: features.loudness,
-      valence: features.valence,
-    };
-    this.musicEmitter.emitSpotify('features', event);
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Removes the usage of the much-used audio features and audio analysis endpoints, [after Spotify decided to abruptly kill these](https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api). Because these endpoints were no longer accessible, a track change was never propagated through Aurora, also breaking that functionality. This is fixed now.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-core/issues/24.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
