### PR TITLE
feat(effects-controller): add support for simple effects controller with preconfigured buttons

### DIFF
--- a/src/helpers/security-groups.ts
+++ b/src/helpers/security-groups.ts
@@ -84,6 +84,7 @@ export const securityGroups = {
   },
   effects: {
     base: baseSecurityGroups,
+    privileged: [SecurityGroup.ADMIN],
   },
   poster: {
     base: allSecuritySubscriberGroups,

--- a/src/modules/handlers/lights/effect-sequence-handler.ts
+++ b/src/modules/handlers/lights/effect-sequence-handler.ts
@@ -1,7 +1,7 @@
 import BaseLightsHandler from '../base-lights-handler';
 import { BeatEvent, TrackChangeEvent } from '../../events/music-emitter-events';
 import { LightsGroup } from '../../lights/entities';
-import { LightsPredefinedEffect } from '../../lights/entities/sequences/lights-predefined-effect';
+import { LightsTrackEffect } from '../../lights/entities/sequences/lights-track-effect';
 import LightsEffect from '../../lights/effects/lights-effect';
 import dataSource from '../../../database';
 import { MusicEmitter } from '../../events';
@@ -26,7 +26,7 @@ interface LightsGroupEffect extends LightsGroupEffectBase {
 }
 
 export default class EffectSequenceHandler extends BaseLightsHandler {
-  private sequence: LightsPredefinedEffect[] = [];
+  private sequence: LightsTrackEffect[] = [];
 
   private sequenceStart: Date = new Date(0);
 
@@ -171,7 +171,7 @@ export default class EffectSequenceHandler extends BaseLightsHandler {
     this.stopSequence(true);
 
     dataSource
-      .getRepository(LightsPredefinedEffect)
+      .getRepository(LightsTrackEffect)
       .find({
         where: { trackUri: event.trackURI },
         relations: { lightGroups: true },

--- a/src/modules/handlers/lights/effects-handler.ts
+++ b/src/modules/handlers/lights/effects-handler.ts
@@ -2,6 +2,7 @@ import BaseLightsHandler from '../base-lights-handler';
 import { LightsGroup } from '../../lights/entities';
 import LightsEffect from '../../lights/effects/lights-effect';
 import { BeatEvent } from '../../events/music-emitter-events';
+import { RgbColor } from '../../lights/color-definitions';
 
 export type GroupEffectsMap = Map<LightsGroup, LightsEffect | LightsEffect[] | null>;
 
@@ -111,5 +112,34 @@ export default abstract class EffectsHandler extends BaseLightsHandler {
         effect.beat(event);
       }
     });
+  }
+
+  /**
+   * Change the color of the given lights group's effects
+   * @param entityCopy
+   * @param colors
+   */
+  updateColors(entityCopy: LightsGroup, colors: RgbColor[]): void {
+    const entity: LightsGroup | undefined = this.entities.find((e) => e.id === entityCopy.id);
+    if (!entity) return;
+
+    const effect = this.groupColorEffects.get(entity);
+    if (Array.isArray(effect)) {
+      effect.forEach((e) => e.setColors(colors));
+    } else {
+      effect?.setColors(colors);
+    }
+  }
+
+  /**
+   * Change the color of the effects of the lights group with the given ID
+   * @param id
+   * @param colors
+   */
+  updateColorsById(id: number, colors: RgbColor[]): void {
+    const entity: LightsGroup | undefined = this.entities.find((e) => e.id === id);
+    if (!entity) return;
+
+    this.updateColors(entity, colors);
   }
 }

--- a/src/modules/handlers/lights/set-effects-handler.ts
+++ b/src/modules/handlers/lights/set-effects-handler.ts
@@ -4,6 +4,7 @@ import { LightsEffectBuilder } from '../../lights/effects/lights-effect';
 import { LIGHTS_EFFECTS, LightsEffectsCreateParams } from '../../lights/effects';
 import { LightsEffectsColorCreateParams } from '../../lights/effects/color';
 import { LightsEffectsMovementCreateParams } from '../../lights/effects/movement';
+import { RgbColor } from '../../lights/color-definitions';
 
 export default class SetEffectsHandler extends EffectsHandler {
   /**

--- a/src/modules/handlers/lights/set-effects-service.ts
+++ b/src/modules/handlers/lights/set-effects-service.ts
@@ -1,0 +1,99 @@
+import { Repository } from 'typeorm';
+import LightsPredefinedEffect, {
+  LightsPredefinedEffectProperties,
+} from '../../lights/entities/scenes/lights-predefined-effect';
+import dataSource from '../../../database';
+import { HttpApiException } from '../../../helpers/custom-error';
+import { HttpStatusCode } from 'axios';
+
+export interface LightsPredefinedEffectResponse {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  buttonId: number;
+  properties: LightsPredefinedEffectProperties;
+}
+
+export interface LightsPredefinedEffectCreateParams
+  extends Pick<LightsPredefinedEffect, 'buttonId' | 'properties'> {}
+
+export interface LightsPredefinedEffectUpdateParams
+  extends Partial<LightsPredefinedEffectCreateParams> {}
+
+export default class SetEffectsService {
+  private repo: Repository<LightsPredefinedEffect>;
+
+  constructor(repo?: Repository<LightsPredefinedEffect>) {
+    this.repo = repo ?? dataSource.getRepository(LightsPredefinedEffect);
+  }
+
+  public static toLightsEffectPredefinedEffectResponse(
+    e: LightsPredefinedEffect,
+  ): LightsPredefinedEffectResponse {
+    return {
+      id: e.id,
+      createdAt: e.createdAt.toISOString(),
+      updatedAt: e.updatedAt.toISOString(),
+      buttonId: e.buttonId,
+      properties: e.properties,
+    };
+  }
+
+  public async getAllPredefinedEffects(): Promise<LightsPredefinedEffect[]> {
+    return this.repo.find();
+  }
+
+  public async getSinglePredefinedEffect({
+    id,
+    buttonId,
+  }: {
+    id?: number;
+    buttonId?: number;
+  }): Promise<LightsPredefinedEffect | null> {
+    return this.repo.findOne({ where: { id, buttonId } });
+  }
+
+  public async createPredefinedEffect(
+    params: LightsPredefinedEffectCreateParams,
+  ): Promise<LightsPredefinedEffect> {
+    const existing = await this.getSinglePredefinedEffect({ buttonId: params.buttonId });
+    if (existing) {
+      throw new HttpApiException(
+        HttpStatusCode.BadRequest,
+        `Effect with button ID "${params.buttonId}" already exists.`,
+      );
+    }
+
+    return this.repo.save(params);
+  }
+
+  public async updatePredefinedEffect(
+    id: number,
+    params: LightsPredefinedEffectUpdateParams,
+  ): Promise<LightsPredefinedEffect> {
+    const existing = await this.getSinglePredefinedEffect({ id });
+    if (!existing) {
+      throw new HttpApiException(HttpStatusCode.NotFound, `Effect with ID "${id}" not found.`);
+    }
+
+    // New button ID
+    if (params.buttonId !== undefined && existing.buttonId !== params.buttonId) {
+      const buttonMatch = await this.getSinglePredefinedEffect({ buttonId: params.buttonId });
+      if (buttonMatch) {
+        throw new HttpApiException(
+          HttpStatusCode.BadRequest,
+          `Effect with button ID "${params.buttonId}" already exists."`,
+        );
+      }
+      existing.buttonId = params.buttonId;
+    }
+
+    if (params.properties) existing.properties = params.properties;
+
+    return this.repo.save(existing);
+  }
+
+  public async deletePredefinedEffect(id: number): Promise<void> {
+    await this.repo.delete(id);
+  }
+}

--- a/src/modules/handlers/lights/set-effects-service.ts
+++ b/src/modules/handlers/lights/set-effects-service.ts
@@ -11,8 +11,8 @@ export interface LightsPredefinedEffectResponse {
   createdAt: string;
   updatedAt: string;
   buttonId: number;
-  icon?: string;
-  name?: string;
+  icon?: string | null;
+  name?: string | null;
   properties: LightsPredefinedEffectProperties;
 }
 

--- a/src/modules/handlers/lights/set-effects-service.ts
+++ b/src/modules/handlers/lights/set-effects-service.ts
@@ -11,11 +11,13 @@ export interface LightsPredefinedEffectResponse {
   createdAt: string;
   updatedAt: string;
   buttonId: number;
+  icon?: string;
+  name?: string;
   properties: LightsPredefinedEffectProperties;
 }
 
 export interface LightsPredefinedEffectCreateParams
-  extends Pick<LightsPredefinedEffect, 'buttonId' | 'properties'> {}
+  extends Pick<LightsPredefinedEffect, 'buttonId' | 'properties' | 'icon' | 'name'> {}
 
 export interface LightsPredefinedEffectUpdateParams
   extends Partial<LightsPredefinedEffectCreateParams> {}
@@ -35,6 +37,8 @@ export default class SetEffectsService {
       createdAt: e.createdAt.toISOString(),
       updatedAt: e.updatedAt.toISOString(),
       buttonId: e.buttonId,
+      name: e.name,
+      icon: e.icon,
       properties: e.properties,
     };
   }
@@ -89,6 +93,8 @@ export default class SetEffectsService {
     }
 
     if (params.properties) existing.properties = params.properties;
+    if (params.name) existing.name = params.name;
+    if (params.icon) existing.icon = params.icon;
 
     return this.repo.save(existing);
   }

--- a/src/modules/lights/effects/color/beat-fade-out.ts
+++ b/src/modules/lights/effects/color/beat-fade-out.ts
@@ -19,6 +19,7 @@ import {
 import EffectProgressionStrategy from '../progression-strategies/effect-progression-strategy';
 import LightsGroupFixture from '../../entities/lights-group-fixture';
 import EffectProgressionMapFactory from '../progression-strategies/mappers/effect-progression-map-factory';
+import { RgbColor } from '../../color-definitions';
 
 export interface BeatFadeOutProps extends BaseLightsEffectProps, BaseLightsEffectProgressionProps {
   /**
@@ -90,6 +91,10 @@ export default class BeatFadeOut extends LightsEffect<BeatFadeOutProps> {
    */
   public static build(props: BeatFadeOutProps): LightsEffectBuilder<BeatFadeOutProps, BeatFadeOut> {
     return (lightsGroup: LightsGroup) => new BeatFadeOut(lightsGroup, props);
+  }
+
+  setColors(colors: RgbColor[]) {
+    this.props.colors = colors;
   }
 
   destroy(): void {}

--- a/src/modules/lights/effects/color/sparkle.ts
+++ b/src/modules/lights/effects/color/sparkle.ts
@@ -5,6 +5,7 @@ import LightsEffect, {
 } from '../lights-effect';
 import { LightsGroup } from '../../entities';
 import { ColorEffects } from './color-effects';
+import { RgbColor } from '../../color-definitions';
 
 export interface SparkleProps extends BaseLightsEffectProps {
   /**
@@ -62,6 +63,10 @@ export default class Sparkle extends LightsEffect<SparkleProps> {
 
   public static build(props: SparkleProps): LightsEffectBuilder<SparkleProps, Sparkle> {
     return (lightsGroup: LightsGroup) => new Sparkle(lightsGroup, props);
+  }
+
+  setColors(colors: RgbColor[]) {
+    this.props.colors = colors;
   }
 
   /**

--- a/src/modules/lights/effects/color/static-color.ts
+++ b/src/modules/lights/effects/color/static-color.ts
@@ -77,6 +77,10 @@ export default class StaticColor extends LightsEffect<StaticColorProps> {
     return (lightsGroup) => new StaticColor(lightsGroup, props);
   }
 
+  setColors(colors: RgbColor[]) {
+    this.props.color = colors[0];
+  }
+
   beat(): void {
     if (!this.props.beatToggle) return;
 

--- a/src/modules/lights/effects/color/wave.ts
+++ b/src/modules/lights/effects/color/wave.ts
@@ -8,6 +8,7 @@ import { LightsGroup, LightsGroupMovingHeadRgbs, LightsGroupPars } from '../../e
 import { ColorEffects } from './color-effects';
 import { EffectProgressionTickStrategy } from '../progression-strategies';
 import EffectProgressionMapFactory from '../progression-strategies/mappers/effect-progression-map-factory';
+import { RgbColor } from '../../color-definitions';
 
 export interface WaveProps extends BaseLightsEffectProps, BaseLightsEffectProgressionProps {
   /**
@@ -54,6 +55,10 @@ export default class Wave extends LightsEffect<WaveProps> {
 
   public static build(props: WaveProps): LightsEffectBuilder<WaveProps, Wave> {
     return (lightsGroup) => new Wave(lightsGroup, props);
+  }
+
+  setColors(colors: RgbColor[]) {
+    this.props.colors = colors;
   }
 
   destroy(): void {}

--- a/src/modules/lights/effects/lights-effect-pattern.ts
+++ b/src/modules/lights/effects/lights-effect-pattern.ts
@@ -1,14 +1,14 @@
 export enum LightsEffectPattern {
-  HORIZONTAL,
-  VERTICAL,
-  DIAGONAL_BOTTOM_LEFT_TO_TOP_RIGHT,
-  DIAGONAL_TOP_LEFT_TO_BOTTOM_RIGHT,
-  CENTERED_CIRCULAR,
-  CENTERED_SQUARED,
-  ROTATIONAL,
+  HORIZONTAL = 'horizontal',
+  VERTICAL = 'vertical',
+  DIAGONAL_BOTTOM_LEFT_TO_TOP_RIGHT = 'diagonal_bottom_left_to_top_right',
+  DIAGONAL_TOP_LEFT_TO_BOTTOM_RIGHT = 'diagonal_top_left_to_bottom_right',
+  CENTERED_CIRCULAR = 'centered_circular',
+  CENTERED_SQUARED = 'centered_squared',
+  ROTATIONAL = 'rotational',
 }
 
 export enum LightsEffectDirection {
-  FORWARDS,
-  BACKWARDS,
+  FORWARDS = 'forwards',
+  BACKWARDS = 'backwards',
 }

--- a/src/modules/lights/effects/lights-effect.ts
+++ b/src/modules/lights/effects/lights-effect.ts
@@ -72,6 +72,14 @@ export default abstract class LightsEffect<P = {}> {
   }
 
   /**
+   * Update the colors of the effect, if applicable.
+   * Intended to be overriden by any effect that
+   * uses colors
+   * @param colors
+   */
+  public setColors(colors: RgbColor[]): void {}
+
+  /**
    * Clean up effect when it is destroyed
    */
   abstract destroy(): void;

--- a/src/modules/lights/entities/colors-rgb.ts
+++ b/src/modules/lights/entities/colors-rgb.ts
@@ -3,6 +3,7 @@ import { RgbColor, rgbColorDefinitions } from '../color-definitions';
 import LightsFixtureShutterOptions, { ShutterOption } from './lights-fixture-shutter-options';
 import Colors from './colors';
 import { IColorsWheel } from './colors-wheel';
+import logger from '../../../logger';
 
 export type ColorChannel = keyof ColorsRgb;
 
@@ -56,8 +57,18 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
     uvChannel: 0,
   };
 
-  public setColor(color: RgbColor): void {
-    this.currentValues = rgbColorDefinitions[color].definition;
+  public setColor(color?: RgbColor): void {
+    if (!color) {
+      this.reset();
+      return;
+    }
+    const spec = rgbColorDefinitions[color];
+    if (!spec) {
+      logger.error(`Color "${color}" not found in rgbColorDefinitions.`);
+      this.reset();
+      return;
+    }
+    this.currentValues = spec.definition;
   }
 
   public setCustomColor(color: IColorsRgb): void {

--- a/src/modules/lights/entities/colors-wheel.ts
+++ b/src/modules/lights/entities/colors-wheel.ts
@@ -6,6 +6,7 @@ import LightsWheelRotateChannelValue from './lights-wheel-rotate-channel-value';
 import { RgbColor, rgbColorDefinitions, WheelColor } from '../color-definitions';
 import Colors from './colors';
 import LightsFixtureShutterOptions, { ShutterOption } from './lights-fixture-shutter-options';
+import logger from '../../../logger';
 
 export interface IColorsWheel {
   colorChannel: number;
@@ -46,8 +47,19 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
     goboRotateChannel: 0,
   };
 
-  public setColor(color: RgbColor): void {
-    const wheelColor = rgbColorDefinitions[color].alternative;
+  public setColor(color?: RgbColor): void {
+    if (!color) {
+      this.reset();
+      return;
+    }
+    const spec = rgbColorDefinitions[color];
+    if (!spec) {
+      logger.error(`Color "${color}" not found in rgbColorDefinitions.`);
+      this.reset();
+      return;
+    }
+
+    const wheelColor = spec.alternative;
     const channelValueObj = this.colorChannelValues.find((v) => v.name === wheelColor);
     this.currentValues = {
       ...this.currentValues,

--- a/src/modules/lights/entities/index.ts
+++ b/src/modules/lights/entities/index.ts
@@ -9,7 +9,7 @@ import LightsGroupMovingHeadWheels from './lights-group-moving-head-wheels';
 import LightsWheelColorChannelValue from './lights-wheel-color-channel-value';
 import LightsWheelGoboChannelValue from './lights-wheel-gobo-channel-value';
 import { LightsScene, LightsSceneEffect } from './scenes';
-import { LightsPredefinedEffect } from './sequences/lights-predefined-effect';
+import { LightsTrackEffect } from './sequences/lights-track-effect';
 import LightsParShutterOptions from './lights-par-shutter-options';
 import LightsMovingHeadRgbShutterOptions from './lights-moving-head-rgb-shutter-options';
 import LightsMovingHeadWheelShutterOptions from './lights-moving-head-wheel-shutter-options';
@@ -42,5 +42,5 @@ export const Entities = [
   LightsSwitch,
   LightsScene,
   LightsSceneEffect,
-  LightsPredefinedEffect,
+  LightsTrackEffect,
 ];

--- a/src/modules/lights/entities/index.ts
+++ b/src/modules/lights/entities/index.ts
@@ -8,7 +8,7 @@ import LightsGroupMovingHeadRgbs from './lights-group-moving-head-rgbs';
 import LightsGroupMovingHeadWheels from './lights-group-moving-head-wheels';
 import LightsWheelColorChannelValue from './lights-wheel-color-channel-value';
 import LightsWheelGoboChannelValue from './lights-wheel-gobo-channel-value';
-import { LightsScene, LightsSceneEffect } from './scenes';
+import { LightsPredefinedEffect, LightsScene, LightsSceneEffect } from './scenes';
 import { LightsTrackEffect } from './sequences/lights-track-effect';
 import LightsParShutterOptions from './lights-par-shutter-options';
 import LightsMovingHeadRgbShutterOptions from './lights-moving-head-rgb-shutter-options';
@@ -42,5 +42,6 @@ export const Entities = [
   LightsSwitch,
   LightsScene,
   LightsSceneEffect,
+  LightsPredefinedEffect,
   LightsTrackEffect,
 ];

--- a/src/modules/lights/entities/lights-moving-head-rgb.ts
+++ b/src/modules/lights/entities/lights-moving-head-rgb.ts
@@ -13,7 +13,7 @@ export default class LightsMovingHeadRgb extends LightsMovingHead {
   @Column(() => ColorsRgb)
   public color: ColorsRgb;
 
-  public setColor(color: RgbColor) {
+  public setColor(color?: RgbColor) {
     this.valuesUpdatedAt = new Date();
     this.color.setColor(color);
   }

--- a/src/modules/lights/entities/lights-moving-head-wheel.ts
+++ b/src/modules/lights/entities/lights-moving-head-wheel.ts
@@ -12,7 +12,7 @@ export default class LightsMovingHeadWheel extends LightsMovingHead {
   @Column(() => ColorsWheel)
   public wheel: ColorsWheel;
 
-  public setColor(color: RgbColor) {
+  public setColor(color?: RgbColor) {
     this.valuesUpdatedAt = new Date();
     this.wheel.setColor(color);
   }

--- a/src/modules/lights/entities/lights-par.ts
+++ b/src/modules/lights/entities/lights-par.ts
@@ -13,7 +13,7 @@ export default class LightsPar extends LightsFixture {
   @Column(() => ColorsRgb)
   public color: ColorsRgb;
 
-  public setColor(color: RgbColor) {
+  public setColor(color?: RgbColor) {
     this.valuesUpdatedAt = new Date();
     this.color.setColor(color);
   }

--- a/src/modules/lights/entities/scenes/index.ts
+++ b/src/modules/lights/entities/scenes/index.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/no-cycle -- cross reference
 export { default as LightsScene } from './lights-scene';
 export { default as LightsSceneEffect } from './lights-scene-effect';
+export { default as LightsPredefinedEffect } from './lights-predefined-effect';

--- a/src/modules/lights/entities/scenes/lights-predefined-effect.ts
+++ b/src/modules/lights/entities/scenes/lights-predefined-effect.ts
@@ -7,6 +7,10 @@ import { RgbColor } from '../../color-definitions';
 export type LightsButtonColors = {
   type: 'LightsButtonColors';
   colors: RgbColor[];
+  /**
+   * Lights groups to which these colors should be immediately applied to
+   */
+  lightsGroupIds?: number[];
 };
 
 export type LightsButtonEffectColor = {
@@ -70,9 +74,9 @@ export default class LightsPredefinedEffect extends BaseEntity {
   })
   properties: LightsPredefinedEffectProperties;
 
-  @Column({ nullable: true })
-  icon?: string;
+  @Column({ nullable: true, type: 'varchar' })
+  icon?: string | null;
 
-  @Column({ nullable: true })
-  name?: string;
+  @Column({ nullable: true, type: 'varchar' })
+  name?: string | null;
 }

--- a/src/modules/lights/entities/scenes/lights-predefined-effect.ts
+++ b/src/modules/lights/entities/scenes/lights-predefined-effect.ts
@@ -1,0 +1,55 @@
+import BaseEntity from '../../../root/entities/base-entity';
+import { Column, Entity } from 'typeorm';
+import { LightsEffectsColorCreateParams } from '../../effects/color';
+import { LightsEffectsMovementCreateParams } from '../../effects/movement';
+import { RgbColor } from '../../color-definitions';
+
+export type LightsButtonColors = {
+  type: 'LightsButtonColors';
+  colors: RgbColor[];
+};
+
+export type LightsButtonEffectColor = {
+  type: 'LightsButtonEffectColor';
+  effectProps: LightsEffectsColorCreateParams;
+  lightsGroupIds: number[];
+};
+
+export type LightsButtonEffectMovement = {
+  type: 'LightsButtonEffectMovement';
+  effectProps: LightsEffectsMovementCreateParams;
+  lightsGroupIds: number[];
+};
+
+export type LightsButtonSwitch = {
+  type: 'LightsButtonSwitch';
+  switchId: number;
+};
+
+export type LightsPredefinedEffectProperties =
+  | LightsButtonColors
+  | LightsButtonEffectColor
+  | LightsButtonEffectMovement
+  | LightsButtonSwitch;
+
+/**
+ * Button on the effect controller board, applying an effect, color, or switch
+ */
+@Entity()
+export default class LightsPredefinedEffect extends BaseEntity {
+  @Column({ type: 'int', unsigned: true, unique: true })
+  buttonId: number;
+
+  @Column({
+    type: 'varchar',
+    transformer: {
+      to(value: LightsPredefinedEffectProperties): string {
+        return JSON.stringify(value);
+      },
+      from(value: string): LightsPredefinedEffectProperties {
+        return JSON.parse(value);
+      },
+    },
+  })
+  properties: LightsPredefinedEffectProperties;
+}

--- a/src/modules/lights/entities/scenes/lights-predefined-effect.ts
+++ b/src/modules/lights/entities/scenes/lights-predefined-effect.ts
@@ -23,14 +23,25 @@ export type LightsButtonEffectMovement = {
 
 export type LightsButtonSwitch = {
   type: 'LightsButtonSwitch';
-  switchId: number;
+  switchIds: number[];
+};
+
+export type LightsButtonStrobe = {
+  type: 'LightsButtonStrobe';
+  lightsGroupIds: number[];
+};
+
+export type LightsButtonNull = {
+  type: 'LightsButtonNull';
 };
 
 export type LightsPredefinedEffectProperties =
   | LightsButtonColors
   | LightsButtonEffectColor
   | LightsButtonEffectMovement
-  | LightsButtonSwitch;
+  | LightsButtonSwitch
+  | LightsButtonStrobe
+  | LightsButtonNull;
 
 /**
  * Button on the effect controller board, applying an effect, color, or switch
@@ -52,4 +63,10 @@ export default class LightsPredefinedEffect extends BaseEntity {
     },
   })
   properties: LightsPredefinedEffectProperties;
+
+  @Column({ nullable: true })
+  icon?: string;
+
+  @Column({ nullable: true })
+  name?: string;
 }

--- a/src/modules/lights/entities/scenes/lights-predefined-effect.ts
+++ b/src/modules/lights/entities/scenes/lights-predefined-effect.ts
@@ -21,6 +21,11 @@ export type LightsButtonEffectMovement = {
   lightsGroupIds: number[];
 };
 
+export type LightsButtonReset = {
+  type: 'LightsButtonReset';
+  lightsGroupIds: number[];
+};
+
 export type LightsButtonSwitch = {
   type: 'LightsButtonSwitch';
   switchIds: number[];
@@ -39,6 +44,7 @@ export type LightsPredefinedEffectProperties =
   | LightsButtonColors
   | LightsButtonEffectColor
   | LightsButtonEffectMovement
+  | LightsButtonReset
   | LightsButtonSwitch
   | LightsButtonStrobe
   | LightsButtonNull;

--- a/src/modules/lights/entities/sequences/lights-track-effect.ts
+++ b/src/modules/lights/entities/sequences/lights-track-effect.ts
@@ -4,7 +4,7 @@ import BaseEntity from '../../../root/entities/base-entity';
 import LightsGroup from '../lights-group';
 
 @Entity()
-export class LightsPredefinedEffect extends BaseEntity {
+export class LightsTrackEffect extends BaseEntity {
   /**
    * Either a Spotify Track URI (spotify:track:<id>) or a local identifier (local:<id>)
    */

--- a/src/modules/root/lights-switch-manager.ts
+++ b/src/modules/root/lights-switch-manager.ts
@@ -44,4 +44,12 @@ export default class LightsSwitchManager {
   public getEnabledSwitches(): LightsSwitch[] {
     return this.enabledSwitches;
   }
+
+  /**
+   * Returns whether the given switch is enabled or disabled
+   * @param lightsSwitch
+   */
+  public switchEnabled(lightsSwitch: LightsSwitch): boolean {
+    return this.enabledSwitches.some((s) => s.id === lightsSwitch.id);
+  }
 }

--- a/src/modules/root/root-lights-controller.ts
+++ b/src/modules/root/root-lights-controller.ts
@@ -1,4 +1,4 @@
-import { Body, Get, Post, Request, Route, Security, Tags } from 'tsoa';
+import { Body, Get, Post, Query, Request, Route, Security, Tags } from 'tsoa';
 import { Controller } from '@tsoa/runtime';
 import RootLightsService, {
   LightsControllerCreateParams,
@@ -60,6 +60,13 @@ export class RootLightsController extends Controller {
     @Body() params: LightsControllerCreateParams,
   ): Promise<LightsControllerResponse> {
     return new RootLightsService().createController(params);
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.light.base)
+  @Get('switch')
+  public async getAllLightsSwitches(@Query() enabled?: boolean): Promise<LightsSwitchResponse[]> {
+    const switches = await new RootLightsService().getAllLightsSwitches(undefined, enabled);
+    return switches.map((s) => RootLightsService.toLightsSwitchResponse(s));
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.light.base)

--- a/src/modules/root/root-lights-service.ts
+++ b/src/modules/root/root-lights-service.ts
@@ -613,13 +613,27 @@ export default class RootLightsService {
     return movingHead;
   }
 
-  public async getAllLightsSwitches(controllerId?: number): Promise<LightsSwitch[]> {
+  public async getAllLightsSwitches(
+    controllerId?: number,
+    enabled?: boolean,
+  ): Promise<LightsSwitch[]> {
     let whereClause: FindOptionsWhere<LightsSwitch> = {};
     if (controllerId) {
       whereClause = { controller: { id: controllerId } };
     }
 
-    return dataSource.getRepository(LightsSwitch).find({ where: whereClause });
+    let switches = await dataSource.getRepository(LightsSwitch).find({ where: whereClause });
+    if (enabled != null) {
+      const manager = LightsSwitchManager.getInstance();
+      switches = switches.filter((s) => {
+        const isEnabled = manager.switchEnabled(s);
+        if (enabled && isEnabled) return true;
+        if (!enabled && !isEnabled) return true;
+        return false;
+      });
+    }
+
+    return switches;
   }
 
   public async createLightsSwitch(

--- a/src/seed/seed.ts
+++ b/src/seed/seed.ts
@@ -6,7 +6,7 @@ import { LightsGroup, LightsMovingHeadWheel } from '../modules/lights/entities';
 import { RgbColor, WheelColor } from '../modules/lights/color-definitions';
 import { SparkleCreateParams } from '../modules/lights/effects/color/sparkle';
 import { StaticColorCreateParams } from '../modules/lights/effects/color/static-color';
-import { LightsPredefinedEffect } from '../modules/lights/entities/sequences/lights-predefined-effect';
+import { LightsTrackEffect } from '../modules/lights/entities/sequences/lights-track-effect';
 import { LightsEffectsCreateParams } from '../modules/lights/effects';
 import { WaveCreateParams } from '../modules/lights/effects/color/wave';
 import { LightsScene, LightsSceneEffect } from '../modules/lights/entities/scenes';
@@ -488,7 +488,7 @@ export async function seedOpeningSequence(
   movingHeadsGEWIS: LightsGroup,
   movingHeadsRoy?: LightsGroup,
 ) {
-  const repo = dataSource.getRepository(LightsPredefinedEffect);
+  const repo = dataSource.getRepository(LightsTrackEffect);
   const trackUri = 'spotify:track:22L7bfCiAkJo5xGSQgmiIO';
 
   const addStep = async (
@@ -504,7 +504,7 @@ export async function seedOpeningSequence(
       effect: effect.type,
       effectProps: JSON.stringify(effect.props),
       lightGroups,
-    } as LightsPredefinedEffect);
+    } as LightsTrackEffect);
   };
 
   const allOfTheLights: SparkleCreateParams = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This PR adds support for the simpler effects controller in the backoffice. Basically, this PR implements a new `LighstPredefinedEffect` entity, which stores a preconfigured button on the controller. This button change change colors, apply effects, turn on/off lights switches, turn on/off the strobe, etc. With this, the user can configure a "board" with buttons that do different things.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-core/issues/33.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_