### PR TITLE
feat(fixtures): add global dimming of light groups

### DIFF
--- a/src/modules/lights/entities/colors-rgb.ts
+++ b/src/modules/lights/entities/colors-rgb.ts
@@ -97,21 +97,34 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
     return value;
   }
 
-  public setStrobeInDmx(values: number[], shutterOptions: LightsFixtureShutterOptions[]): number[] {
-    if (this.masterDimChannel) values[this.masterDimChannel - 1] = 255;
+  public setStrobeInDmx(
+    masterRelativeBrightness: number,
+    values: number[],
+    shutterOptions: LightsFixtureShutterOptions[],
+  ): number[] {
+    const brightnessValue = Math.round(masterRelativeBrightness * 255);
+    if (this.masterDimChannel) values[this.masterDimChannel - 1] = brightnessValue;
     if (this.shutterChannel)
       values[this.shutterChannel - 1] =
         shutterOptions.find((o) => o.shutterOption === ShutterOption.STROBE)?.channelValue ?? 0;
 
-    if (this.shutterChannel || this.strobePing) {
-      // If we have a shutter channel or we should manually strobe
+    if (this.shutterChannel) {
+      // If we have a shutter channel
       values[this.redChannel - 1] = 255;
       values[this.blueChannel - 1] = 255;
       values[this.greenChannel - 1] = 255;
       if (this.warmWhiteChannel) values[this.warmWhiteChannel - 1] = 255;
       if (this.coldWhiteChannel) values[this.coldWhiteChannel - 1] = 255;
       if (this.amberChannel) values[this.amberChannel - 1] = 255;
-    } else if (!this.shutterChannel) {
+    } else if (this.strobePing) {
+      // If we should manually strobe
+      values[this.redChannel - 1] = brightnessValue;
+      values[this.blueChannel - 1] = brightnessValue;
+      values[this.greenChannel - 1] = brightnessValue;
+      if (this.warmWhiteChannel) values[this.warmWhiteChannel - 1] = brightnessValue;
+      if (this.coldWhiteChannel) values[this.coldWhiteChannel - 1] = brightnessValue;
+      if (this.amberChannel) values[this.amberChannel - 1] = brightnessValue;
+    } else {
       // If we do not have a shutter channel and the ping is off,
       // turn off all colors
       values[this.redChannel - 1] = 0;
@@ -130,9 +143,15 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
     return values;
   }
 
-  public setColorsInDmx(values: number[], shutterOptions: LightsFixtureShutterOptions[]): number[] {
+  public setColorsInDmx(
+    masterRelativeBrightness: number,
+    values: number[],
+    shutterOptions: LightsFixtureShutterOptions[],
+  ): number[] {
     if (this.masterDimChannel)
-      values[this.masterDimChannel - 1] = Math.round(this.currentBrightness * 255);
+      values[this.masterDimChannel - 1] = Math.round(
+        this.currentBrightness * masterRelativeBrightness * 255,
+      );
     if (this.shutterChannel)
       values[this.shutterChannel - 1] =
         shutterOptions.find((o) => o.shutterOption === ShutterOption.OPEN)?.channelValue ?? 0;

--- a/src/modules/lights/entities/colors-wheel.ts
+++ b/src/modules/lights/entities/colors-wheel.ts
@@ -95,7 +95,11 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
     return this.currentValues;
   }
 
-  public setStrobeInDmx(values: number[], shutterOptions: LightsFixtureShutterOptions[]): number[] {
+  public setStrobeInDmx(
+    masterRelativeBrightness: number,
+    values: number[],
+    shutterOptions: LightsFixtureShutterOptions[],
+  ): number[] {
     if (this.shutterChannel)
       values[this.shutterChannel - 1] =
         shutterOptions.find((o) => o.shutterOption === ShutterOption.STROBE)?.channelValue ?? 0;
@@ -105,7 +109,7 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
     if (this.shutterChannel || this.strobePing) {
       // If we have a shutter channel or we should manually strobe,
       // turn on the light
-      values[this.masterDimChannel - 1] = 255;
+      values[this.masterDimChannel - 1] = Math.round(masterRelativeBrightness * 255);
     } else if (!this.shutterChannel) {
       // If we do not have a shutter channel and the ping is off,
       // turn off the light
@@ -119,8 +123,14 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
     return values;
   }
 
-  public setColorsInDmx(values: number[], shutterOptions: LightsFixtureShutterOptions[]): number[] {
-    values[this.masterDimChannel - 1] = Math.round(this.currentBrightness * 255);
+  public setColorsInDmx(
+    masterRelativeBrightness: number,
+    values: number[],
+    shutterOptions: LightsFixtureShutterOptions[],
+  ): number[] {
+    values[this.masterDimChannel - 1] = Math.round(
+      masterRelativeBrightness * this.currentBrightness * 255,
+    );
     if (this.shutterChannel)
       values[this.shutterChannel - 1] =
         shutterOptions.find((o) => o.shutterOption === ShutterOption.OPEN)?.channelValue ?? 0;

--- a/src/modules/lights/entities/colors.ts
+++ b/src/modules/lights/entities/colors.ts
@@ -59,17 +59,26 @@ export default abstract class Colors {
     return this.strobe;
   }
 
+  /**
+   * Apply strobe effect to the given DMX subpacket
+   * @param masterRelativeBrightness Value in [0, 1], indicating the master dimmer value
+   * @param values DMX subpacket
+   * @param shutterOptions Fixture's shutter options
+   */
   public abstract setStrobeInDmx(
+    masterRelativeBrightness: number,
     values: number[],
     shutterOptions: LightsFixtureShutterOptions[],
   ): number[];
 
   /**
    * Apply colors to the given DMX subpacket (in-place)
-   * @param values
-   * @param shutterOptions
+   * @param masterRelativeBrightness Value in [0, 1], indicating the master dimmer value
+   * @param values DMX subpacket
+   * @param shutterOptions Fixture's shutter options
    */
   public abstract setColorsInDmx(
+    masterRelativeBrightness: number,
     values: number[],
     shutterOptions: LightsFixtureShutterOptions[],
   ): number[];

--- a/src/modules/lights/entities/lights-fixture.ts
+++ b/src/modules/lights/entities/lights-fixture.ts
@@ -124,25 +124,25 @@ export default abstract class LightsFixture extends BaseEntity {
    * Get the DMX channels that should be used when the fixture should strobe
    * @protected
    */
-  protected abstract getStrobeDMX(): number[];
+  protected abstract getStrobeDMX(masterRelativeBrightness: number): number[];
 
   /**
    * Get the DMX channels that are created from the channel values
    * @protected
    */
-  protected abstract getDmxFromCurrentValues(): number[];
+  protected abstract getDmxFromCurrentValues(masterRelativeBrightness: number): number[];
 
   /**
    * Get the current DMX values as an 16-length array of integers.
    */
-  toDmx(): number[] {
-    if (this.strobeEnabled()) return this.getStrobeDMX();
+  toDmx(relativeBrightness: number = 1): number[] {
+    if (this.strobeEnabled()) return this.getStrobeDMX(relativeBrightness);
 
     if (this.frozenDmx != null && this.frozenDmx.length > 0) {
       return this.frozenDmx;
     }
 
-    let values: number[] = this.getDmxFromCurrentValues();
+    let values: number[] = this.getDmxFromCurrentValues(relativeBrightness);
     values = this.applyDmxOverride(values);
 
     if (this.shouldReset !== undefined) {

--- a/src/modules/lights/entities/lights-fixture.ts
+++ b/src/modules/lights/entities/lights-fixture.ts
@@ -1,6 +1,7 @@
 import { AfterLoad, Column } from 'typeorm';
 import BaseEntity from '../../root/entities/base-entity';
 import { RgbColor } from '../color-definitions';
+import { DEFAULT_MASTER_DIMMER } from './lights-group-fixture';
 
 export default abstract class LightsFixture extends BaseEntity {
   @Column()
@@ -135,7 +136,7 @@ export default abstract class LightsFixture extends BaseEntity {
   /**
    * Get the current DMX values as an 16-length array of integers.
    */
-  toDmx(relativeBrightness: number = 1): number[] {
+  toDmx(relativeBrightness: number = DEFAULT_MASTER_DIMMER): number[] {
     if (this.strobeEnabled()) return this.getStrobeDMX(relativeBrightness);
 
     if (this.frozenDmx != null && this.frozenDmx.length > 0) {

--- a/src/modules/lights/entities/lights-group-fixture.ts
+++ b/src/modules/lights/entities/lights-group-fixture.ts
@@ -11,7 +11,19 @@ export default abstract class LightsGroupFixture extends BaseEntity {
   @Column({ type: 'smallint', unsigned: true })
   public firstChannel: number;
 
+  /**
+   * Relative brightness of a fixture, applied on top of the relative
+   * brightness applied by an effect
+   */
+  @Column({ type: 'double', default: 1 })
+  public masterRelativeBrightness: number;
+
   public getActualChannel(relativeChannel: number) {
     return relativeChannel + this.firstChannel - 1;
   }
+
+  /**
+   * Get the current DMX values as an 16-length array of integers.
+   */
+  public abstract toDmx(): number[];
 }

--- a/src/modules/lights/entities/lights-group-fixture.ts
+++ b/src/modules/lights/entities/lights-group-fixture.ts
@@ -1,6 +1,8 @@
 import BaseEntity from '../../root/entities/base-entity';
 import { Column } from 'typeorm';
 
+export const DEFAULT_MASTER_DIMMER = 1;
+
 export default abstract class LightsGroupFixture extends BaseEntity {
   @Column({ type: 'real', unsigned: true, nullable: false })
   public positionX: number;
@@ -15,7 +17,7 @@ export default abstract class LightsGroupFixture extends BaseEntity {
    * Relative brightness of a fixture, applied on top of the relative
    * brightness applied by an effect
    */
-  @Column({ type: 'double', default: 1 })
+  @Column({ type: 'double', default: DEFAULT_MASTER_DIMMER })
   public masterRelativeBrightness: number;
 
   public getActualChannel(relativeChannel: number) {

--- a/src/modules/lights/entities/lights-group-moving-head-rgbs.ts
+++ b/src/modules/lights/entities/lights-group-moving-head-rgbs.ts
@@ -14,4 +14,8 @@ export default class LightsGroupMovingHeadRgbs extends LightsGroupFixture {
   @ManyToOne(() => LightsMovingHeadRgb, { eager: true })
   @JoinColumn()
   public fixture: LightsMovingHeadRgb;
+
+  public toDmx(): number[] {
+    return this.fixture.toDmx(this.masterRelativeBrightness);
+  }
 }

--- a/src/modules/lights/entities/lights-group-moving-head-wheels.ts
+++ b/src/modules/lights/entities/lights-group-moving-head-wheels.ts
@@ -13,4 +13,8 @@ export default class LightsGroupMovingHeadWheels extends LightsGroupFixture {
   @ManyToOne(() => LightsMovingHeadWheel, { eager: true })
   @JoinColumn()
   public fixture: LightsMovingHeadWheel;
+
+  public toDmx(): number[] {
+    return this.fixture.toDmx(this.masterRelativeBrightness);
+  }
 }

--- a/src/modules/lights/entities/lights-group-pars.ts
+++ b/src/modules/lights/entities/lights-group-pars.ts
@@ -13,4 +13,8 @@ export default class LightsGroupPars extends LightsGroupFixture {
   @ManyToOne(() => LightsPar, { eager: true })
   @JoinColumn()
   public fixture: LightsPar;
+
+  public toDmx(): number[] {
+    return this.fixture.toDmx(this.masterRelativeBrightness);
+  }
 }

--- a/src/modules/lights/entities/lights-moving-head-rgb.ts
+++ b/src/modules/lights/entities/lights-moving-head-rgb.ts
@@ -56,10 +56,10 @@ export default class LightsMovingHeadRgb extends LightsMovingHead {
    * Get the DMX packet for a strobing light
    * @protected
    */
-  protected getStrobeDMX(): number[] {
+  protected getStrobeDMX(masterRelativeBrightness: number): number[] {
     let values = this.getEmptyDmxSubPacket();
 
-    values = this.color.setStrobeInDmx(values, this.shutterOptions);
+    values = this.color.setStrobeInDmx(masterRelativeBrightness, values, this.shutterOptions);
     values = this.setPositionInDmx(values);
 
     if (!this.color.shutterChannel) {
@@ -72,10 +72,10 @@ export default class LightsMovingHeadRgb extends LightsMovingHead {
     return values;
   }
 
-  public getDmxFromCurrentValues(): number[] {
+  public getDmxFromCurrentValues(masterRelativeBrightness: number): number[] {
     let values = this.getEmptyDmxSubPacket();
 
-    values = this.color.setColorsInDmx(values, this.shutterOptions);
+    values = this.color.setColorsInDmx(masterRelativeBrightness, values, this.shutterOptions);
     values = this.setPositionInDmx(values);
 
     return values;

--- a/src/modules/lights/entities/lights-moving-head-wheel.ts
+++ b/src/modules/lights/entities/lights-moving-head-wheel.ts
@@ -60,10 +60,10 @@ export default class LightsMovingHeadWheel extends LightsMovingHead {
    * Get the DMX packet for a strobing light
    * @protected
    */
-  protected getStrobeDMX(): number[] {
+  protected getStrobeDMX(masterRelativeBrightness: number): number[] {
     let values = this.getEmptyDmxSubPacket();
 
-    values = this.wheel.setStrobeInDmx(values, this.shutterOptions);
+    values = this.wheel.setStrobeInDmx(masterRelativeBrightness, values, this.shutterOptions);
     values = this.setPositionInDmx(values);
 
     if (!this.wheel.shutterChannel) {
@@ -76,10 +76,10 @@ export default class LightsMovingHeadWheel extends LightsMovingHead {
     return values;
   }
 
-  public getDmxFromCurrentValues(): number[] {
+  public getDmxFromCurrentValues(masterRelativeBrightness: number): number[] {
     let values = this.getEmptyDmxSubPacket();
 
-    values = this.wheel.setColorsInDmx(values, this.shutterOptions);
+    values = this.wheel.setColorsInDmx(masterRelativeBrightness, values, this.shutterOptions);
     values = this.setPositionInDmx(values);
 
     return values;

--- a/src/modules/lights/entities/lights-par.ts
+++ b/src/modules/lights/entities/lights-par.ts
@@ -56,9 +56,9 @@ export default class LightsPar extends LightsFixture {
    * Get the DMX packet for a strobing light (16 channels)
    * @protected
    */
-  protected getStrobeDMX(): number[] {
+  protected getStrobeDMX(masterRelativeBrightness: number): number[] {
     let values = this.getEmptyDmxSubPacket();
-    values = this.color.setStrobeInDmx(values, this.shutterOptions);
+    values = this.color.setStrobeInDmx(masterRelativeBrightness, values, this.shutterOptions);
 
     if (!this.color.shutterChannel) {
       // The getStrobeInDmx() value changes its state if we need to
@@ -70,10 +70,10 @@ export default class LightsPar extends LightsFixture {
     return values;
   }
 
-  public getDmxFromCurrentValues(): number[] {
+  public getDmxFromCurrentValues(masterRelativeBrightness: number): number[] {
     let values = this.getEmptyDmxSubPacket();
 
-    values = this.color.setColorsInDmx(values, this.shutterOptions);
+    values = this.color.setColorsInDmx(masterRelativeBrightness, values, this.shutterOptions);
 
     return values;
   }

--- a/src/modules/root/handler-service.ts
+++ b/src/modules/root/handler-service.ts
@@ -3,6 +3,8 @@ import dataSource from '../../database';
 import { Audio, Screen } from './entities';
 import { LightsGroup } from '../lights/entities';
 import ModeManager from '../modes/mode-manager';
+import RootLightsOperationsService from './root-lights-operations-service';
+import { DEFAULT_MASTER_DIMMER } from '../lights/entities/lights-group-fixture';
 
 export default class HandlerService {
   private handlerManager: HandlerManager;
@@ -19,10 +21,18 @@ export default class HandlerService {
     const screens = await dataSource.getRepository(Screen).find();
     const lights = await dataSource.getRepository(LightsGroup).find();
 
+    // Set all subscribers to their default handlers (can be none)
     audios.forEach((audio) => this.handlerManager.registerHandler(audio, audio.defaultHandler));
     screens.forEach((screen) => this.handlerManager.registerHandler(screen, screen.defaultHandler));
     lights.forEach((group) => this.handlerManager.registerHandler(group, group.defaultHandler));
 
+    // Disable all modes
     this.modeManager.reset();
+
+    // Set all master dimmers back to their defaults
+    const rootLightsOpsService = new RootLightsOperationsService();
+    await Promise.all(
+      lights.map((l) => rootLightsOpsService.resetLightsGroupRelativeBrightness(l.id)),
+    );
   }
 }

--- a/src/modules/root/lights-controller-manager.ts
+++ b/src/modules/root/lights-controller-manager.ts
@@ -124,7 +124,7 @@ export default class LightsControllerManager {
     p: LightsGroupPars | LightsGroupMovingHeadRgbs | LightsGroupMovingHeadWheels,
     packet: number[],
   ) {
-    const dmxValues = p.fixture.toDmx();
+    const dmxValues = p.toDmx();
 
     for (let i = 0; i < dmxValues.length; i++) {
       packet[p.firstChannel - 1 + i] = dmxValues[i];

--- a/src/modules/root/root-lights-operations-service.ts
+++ b/src/modules/root/root-lights-operations-service.ts
@@ -1,0 +1,70 @@
+import dataSource from '../../database';
+import {
+  LightsGroup,
+  LightsGroupMovingHeadRgbs,
+  LightsGroupMovingHeadWheels,
+  LightsGroupPars,
+} from '../lights/entities';
+import HandlerManager from './handler-manager';
+import { DEFAULT_MASTER_DIMMER } from '../lights/entities/lights-group-fixture';
+
+export default class RootLightsOperationsService {
+  /**
+   * Get all lights groups that are present in memory
+   */
+  public getGroups(): LightsGroup[] {
+    const manager = HandlerManager.getInstance();
+    return manager
+      .getHandlers(LightsGroup)
+      .map((handler) => handler.entities)
+      .flat() as LightsGroup[];
+  }
+
+  /**
+   * Set the master dimmer for all fixtures in a group, both in-memory and in the database
+   * @param id
+   * @param masterRelativeBrightness
+   */
+  public async applyLightsGroupRelativeBrightness(id: number, masterRelativeBrightness: number) {
+    // Apply the master relative brightness to the existing in-memory fixtures
+    const memGroup = this.getGroups().find((g) => g.id === id);
+    if (memGroup) {
+      memGroup.fixtures.forEach((f) => {
+        // TODO: refactor to not manually update valuesUpdatedAt outside entities
+        f.masterRelativeBrightness = masterRelativeBrightness;
+        f.fixture.valuesUpdatedAt = new Date();
+      });
+    }
+
+    const dbLightsGroup = await dataSource.getRepository(LightsGroup).findOne({
+      where: { id },
+      relations: { pars: true, movingHeadRgbs: true, movingHeadWheels: true },
+    });
+    if (!dbLightsGroup) return;
+
+    // Store the master brightness in the database, in case a lights group switches handlers
+    if (dbLightsGroup.pars.length > 0)
+      await dataSource.getRepository(LightsGroupPars).update(
+        dbLightsGroup.pars.map((p) => p.id),
+        { masterRelativeBrightness },
+      );
+    if (dbLightsGroup.movingHeadRgbs.length > 0)
+      await dataSource.getRepository(LightsGroupMovingHeadRgbs).update(
+        dbLightsGroup.movingHeadRgbs.map((p) => p.id),
+        { masterRelativeBrightness },
+      );
+    if (dbLightsGroup.movingHeadWheels.length > 0)
+      await dataSource.getRepository(LightsGroupMovingHeadWheels).update(
+        dbLightsGroup.movingHeadWheels.map((p) => p.id),
+        { masterRelativeBrightness },
+      );
+  }
+
+  /**
+   * Reset master dimmer for given lights group to default
+   * @param id
+   */
+  public async resetLightsGroupRelativeBrightness(id: number) {
+    return this.applyLightsGroupRelativeBrightness(id, DEFAULT_MASTER_DIMMER);
+  }
+}

--- a/src/modules/root/root-lights-service.ts
+++ b/src/modules/root/root-lights-service.ts
@@ -81,6 +81,7 @@ export interface FixtureInGroupResponse<
   firstChannel: number;
   positionX: number;
   positionY: number;
+  masterDimmer: number;
 }
 
 export interface BaseLightsGroupResponse
@@ -332,6 +333,7 @@ export default class RootLightsService {
         firstChannel: p.firstChannel,
         positionX: p.positionX,
         positionY: p.positionY,
+        masterDimmer: p.masterRelativeBrightness,
       })),
       movingHeadRgbs: g.movingHeadRgbs.map((m) => ({
         fixture: this.toMovingHeadRgbResponse(m.fixture, m.firstChannel),
@@ -339,6 +341,7 @@ export default class RootLightsService {
         firstChannel: m.firstChannel,
         positionX: m.positionX,
         positionY: m.positionY,
+        masterDimmer: m.masterRelativeBrightness,
       })),
       movingHeadWheels: g.movingHeadWheels.map((m) => ({
         fixture: this.toMovingHeadWheelResponse(m.fixture, m.firstChannel),
@@ -346,6 +349,7 @@ export default class RootLightsService {
         firstChannel: m.firstChannel,
         positionX: m.positionX,
         positionY: m.positionY,
+        masterDimmer: m.masterRelativeBrightness,
       })),
     };
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds a master dimmer value to every fixture in every lights group. This value between 0 (off) and 1 (full brightness) is globally applied across all effects. To prevent "deadlocks" due to people misunderstanding why a fixture is not working because its master dimmer is set to 0, all master dimmers are reset with the `reset-system-defaults` endpoint and timed event.

Due to time constraints, this PR does not include dimming of individual fixtures within a group. However, this is very easy to implement by simply adding some extra endpoints for each type of fixture.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-core/issues/31.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_