### PR TITLE
feat(lights-effects): add new background pulse, random color and zigzag movement effects

### DIFF
--- a/src/modules/lights/effects/color/background-pulse.ts
+++ b/src/modules/lights/effects/color/background-pulse.ts
@@ -1,0 +1,180 @@
+import LightsEffect, {
+  BaseLightsEffectCreateParams,
+  BaseLightsEffectProps,
+  LightsEffectBuilder,
+} from '../lights-effect';
+import { LightsGroup } from '../../entities';
+import { RgbColor, rgbColorDefinitions } from '../../color-definitions';
+import { EffectProgressionTickStrategy } from '../progression-strategies';
+import { IColorsRgb } from '../../entities/colors-rgb';
+import { ColorEffects } from './color-effects';
+
+export interface BackgroundPulseProps extends BaseLightsEffectProps {
+  /**
+   * What percentage (on average) of the lights should be turned on
+   * @minimum 0
+   * @maximum 1
+   */
+  ratio?: number;
+
+  /**
+   * How many ms the lights should take to turn on and aff
+   * @isInt
+   * @minimum 1
+   */
+  pulseDuration?: number;
+
+  /**
+   * After how many ms (approximately) a ratio of lights should start pulsing.
+   * @isInt
+   * @minimum 0
+   */
+  cycleTime?: number;
+}
+
+export type BackgroundPulseCreateParams = BaseLightsEffectCreateParams & {
+  type: ColorEffects.BackgroundPulse;
+  props: BackgroundPulseProps;
+};
+
+const DEFAULT_RATIO = 0.05;
+const DEFAULT_PULSE_DURATION = 8000;
+const DEFAULT_CYCLE_TIME = 800;
+
+export default class BackgroundPulse extends LightsEffect<BackgroundPulseProps> {
+  private progressions: (EffectProgressionTickStrategy | undefined)[];
+
+  private colorIndices: number[];
+
+  private cycleStartTick: Date = new Date();
+
+  constructor(lightsGroup: LightsGroup, props: BackgroundPulseProps) {
+    super(lightsGroup);
+
+    const nrFixtures = lightsGroup.pars.length + lightsGroup.movingHeadRgbs.length;
+    const nrPulseColors = props.colors.length - 1;
+    this.progressions = new Array(nrFixtures).fill(undefined);
+    this.colorIndices = new Array(nrFixtures).fill(0).map(() => {
+      return Math.floor(Math.random() * nrPulseColors);
+    });
+
+    this.props = props;
+  }
+
+  public static build(
+    props: BackgroundPulseProps,
+  ): LightsEffectBuilder<BackgroundPulseProps, BackgroundPulse> {
+    return (lightsGroup: LightsGroup) => new BackgroundPulse(lightsGroup, props);
+  }
+
+  setColors(colors: RgbColor[]) {
+    this.props.colors = colors;
+  }
+
+  destroy(): void {}
+
+  /**
+   * Whether we should start a new tick
+   * @private
+   */
+  private shouldStartNewCycle(): boolean {
+    const now = new Date();
+    const ms = now.getTime() - this.cycleStartTick.getTime();
+    return ms > (this.props.cycleTime || DEFAULT_CYCLE_TIME);
+  }
+
+  /**
+   * Have a subset of fixtures start a new pulse, if they are not pulsing already
+   * @private
+   */
+  private startNewCycle(): void {
+    this.cycleStartTick = new Date();
+
+    const candidateFixtureIndices = this.progressions
+      .map((p, i) => i)
+      .filter((i) => {
+        const p = this.progressions[i];
+        return !p || p.getProgression(this.cycleStartTick) >= 1;
+      });
+
+    let nrFixturesToStart = this.progressions.length * (this.props.ratio || DEFAULT_RATIO);
+    const extraFixture = nrFixturesToStart % 1 > Math.random();
+    if (extraFixture) {
+      nrFixturesToStart = Math.ceil(nrFixturesToStart);
+    } else {
+      nrFixturesToStart = Math.floor(nrFixturesToStart);
+    }
+
+    const fixtureIndicesPermutation = candidateFixtureIndices.sort(() => Math.random() - 0.5);
+    const fixturesToStart = fixtureIndicesPermutation.slice(0, nrFixturesToStart);
+    fixturesToStart.forEach((i) => {
+      this.progressions[i] = new EffectProgressionTickStrategy(
+        this.props.pulseDuration || DEFAULT_PULSE_DURATION,
+        true,
+      );
+      // Next color. Note that the first color is always the background color
+      this.colorIndices[i] = (this.colorIndices[i] + 1) % (this.props.colors.length - 1);
+    });
+  }
+
+  /**
+   * Transform a [0, 1] linear progression to a [0, 1] and [1, 0] linear progression
+   * @param fixtureAbsoluteProgression
+   * @protected
+   */
+  protected getRelativeProgression(fixtureAbsoluteProgression: number) {
+    if (fixtureAbsoluteProgression < 0.5) {
+      return fixtureAbsoluteProgression * 2;
+    }
+    return (1 - fixtureAbsoluteProgression) * 2;
+  }
+
+  /**
+   * Get the mixed color for the given progression and the given color index
+   * @param p progression, in range [0, 1]
+   * @param colorIndex
+   * @private
+   */
+  private getColor(p: number, colorIndex: number): Required<IColorsRgb> {
+    const baseColor = rgbColorDefinitions[this.props.colors[0]].definition;
+    if (p <= 0 || this.props.colors.length < 2) {
+      return baseColor;
+    }
+
+    const compositeColor = rgbColorDefinitions[this.props.colors[colorIndex]].definition;
+
+    return {
+      redChannel: baseColor.redChannel * (1 - p) + compositeColor.redChannel * p,
+      greenChannel: baseColor.greenChannel * (1 - p) + compositeColor.greenChannel * p,
+      blueChannel: baseColor.blueChannel * (1 - p) + compositeColor.blueChannel * p,
+      warmWhiteChannel:
+        baseColor.warmWhiteChannel! * (1 - p) + compositeColor.warmWhiteChannel! * p,
+      coldWhiteChannel:
+        baseColor.coldWhiteChannel! * (1 - p) + compositeColor.coldWhiteChannel! * p,
+      amberChannel: baseColor.amberChannel! * (1 - p) + compositeColor.amberChannel! * p,
+      uvChannel: baseColor.uvChannel! * (1 - p) + compositeColor.uvChannel! * p,
+    };
+  }
+
+  tick(): LightsGroup {
+    if (this.shouldStartNewCycle()) {
+      this.startNewCycle();
+    }
+
+    const tick = new Date();
+
+    [...this.lightsGroup.pars, ...this.lightsGroup.movingHeadRgbs].forEach((f, i) => {
+      const progressionStrategy = this.progressions[i];
+
+      let p = 0;
+      if (progressionStrategy) {
+        p = this.getRelativeProgression(progressionStrategy.getProgression(tick));
+      }
+
+      const color = this.getColor(p, this.colorIndices[i] + 1);
+      f.fixture.setCustomColor(color);
+    });
+
+    return this.lightsGroup;
+  }
+}

--- a/src/modules/lights/effects/color/color-effects.ts
+++ b/src/modules/lights/effects/color/color-effects.ts
@@ -1,5 +1,6 @@
 // Exists mostly for proper typing in the frontend
 export enum ColorEffects {
+  BackgroundPulse = 'BackgroundPulse',
   BeatFadeOut = 'BeatFadeOut',
   SingleFlood = 'SingleFlood',
   Sparkle = 'Sparkle',

--- a/src/modules/lights/effects/color/color-effects.ts
+++ b/src/modules/lights/effects/color/color-effects.ts
@@ -2,6 +2,7 @@
 export enum ColorEffects {
   BackgroundPulse = 'BackgroundPulse',
   BeatFadeOut = 'BeatFadeOut',
+  RandomColor = 'RandomColor',
   SingleFlood = 'SingleFlood',
   Sparkle = 'Sparkle',
   StaticColor = 'StaticColor',

--- a/src/modules/lights/effects/color/index.ts
+++ b/src/modules/lights/effects/color/index.ts
@@ -6,10 +6,12 @@ import Wave, { WaveCreateParams } from './wave';
 import StaticColor, { StaticColorCreateParams } from './static-color';
 import Fire, { FireCreateParams } from './fire';
 import BackgroundPulse, { BackgroundPulseCreateParams } from './background-pulse';
+import RandomColor, { RandomColorCreateParams } from './random-color';
 
 export { default as BackgroundPulse } from './background-pulse';
 export { default as BeatFadeOut } from './beat-fade-out';
 export { default as Fire } from './fire';
+export { default as RandomColor } from './random-color';
 export { default as Strobe } from './strobe';
 export { default as SingleFlood } from './single-flood';
 export { default as Sparkle } from './sparkle';
@@ -20,6 +22,7 @@ export type LightsEffectsColorCreateParams =
   | BackgroundPulseCreateParams
   | BeatFadeOutCreateParams
   | FireCreateParams
+  | RandomColorCreateParams
   | SingleFloodCreateParams
   | SparkleCreateParams
   | StaticColorCreateParams
@@ -30,6 +33,7 @@ export const LIGHTS_EFFECTS_COLOR = [
   BackgroundPulse,
   BeatFadeOut,
   Fire,
+  RandomColor,
   SingleFlood,
   Sparkle,
   StaticColor,

--- a/src/modules/lights/effects/color/index.ts
+++ b/src/modules/lights/effects/color/index.ts
@@ -5,7 +5,9 @@ import Strobe, { StrobeCreateParams } from './strobe';
 import Wave, { WaveCreateParams } from './wave';
 import StaticColor, { StaticColorCreateParams } from './static-color';
 import Fire, { FireCreateParams } from './fire';
+import BackgroundPulse, { BackgroundPulseCreateParams } from './background-pulse';
 
+export { default as BackgroundPulse } from './background-pulse';
 export { default as BeatFadeOut } from './beat-fade-out';
 export { default as Fire } from './fire';
 export { default as Strobe } from './strobe';
@@ -15,6 +17,7 @@ export { default as StaticColor } from './static-color';
 export { default as Wave } from './wave';
 
 export type LightsEffectsColorCreateParams =
+  | BackgroundPulseCreateParams
   | BeatFadeOutCreateParams
   | FireCreateParams
   | SingleFloodCreateParams
@@ -24,6 +27,7 @@ export type LightsEffectsColorCreateParams =
   | WaveCreateParams;
 
 export const LIGHTS_EFFECTS_COLOR = [
+  BackgroundPulse,
   BeatFadeOut,
   Fire,
   SingleFlood,

--- a/src/modules/lights/effects/color/random-color.ts
+++ b/src/modules/lights/effects/color/random-color.ts
@@ -1,0 +1,101 @@
+import LightsEffect, {
+  BaseLightsEffectCreateParams,
+  BaseLightsEffectProps,
+  LightsEffectBuilder,
+} from '../lights-effect';
+import { ColorEffects } from './color-effects';
+import { LightsGroup } from '../../entities';
+import { RgbColor } from '../../color-definitions';
+import { BeatEvent } from '../../../events/music-emitter-events';
+
+export interface RandomColorProps extends BaseLightsEffectProps {
+  /**
+   * How many "black" fixtures should be added. Zero for no blacks
+   * @isInt
+   * @minimum 0
+   */
+  nrBlacks?: number;
+
+  /**
+   * Amount of time it takes before the lights switch to the next state (in ms). If undefined,
+   * beats will be used for switching states
+   * @isInt
+   * @minimum 0
+   */
+  customCycleTime?: number;
+}
+
+export type RandomColorCreateParams = BaseLightsEffectCreateParams & {
+  type: ColorEffects.RandomColor;
+  props: RandomColorProps;
+};
+
+export default class RandomColor extends LightsEffect<RandomColorProps> {
+  private readonly nrSteps: number;
+
+  private colorIndices: number[];
+
+  private startTick = new Date();
+
+  constructor(lightsGroup: LightsGroup, props: RandomColorProps) {
+    super(lightsGroup);
+
+    this.nrSteps = props.colors.length + (props.nrBlacks || 0);
+    this.props = props;
+
+    const nrFixtures = lightsGroup.pars.length + lightsGroup.movingHeadRgbs.length;
+    this.colorIndices = new Array(nrFixtures).fill(0);
+    this.assignNewColorPermutation();
+  }
+
+  public static build(props: RandomColorProps): LightsEffectBuilder<RandomColorProps, RandomColor> {
+    return (lightsGroup: LightsGroup) => new RandomColor(lightsGroup, props);
+  }
+
+  /**
+   * Give each fixture a random color based on a permutation
+   * @private
+   */
+  private assignNewColorPermutation() {
+    const indices = this.colorIndices.map((_, i) => i);
+    const fixturesPerColor = indices.length / this.nrSteps;
+
+    const permutation = indices.sort(() => Math.random() - 0.5);
+    permutation.forEach((i1, i2) => {
+      this.colorIndices[i1] = Math.floor(i2 / fixturesPerColor);
+    });
+  }
+
+  setColors(colors: RgbColor[]) {
+    this.props.colors = colors;
+  }
+
+  destroy() {}
+
+  beat(event: BeatEvent) {
+    super.beat(event);
+
+    if (this.props.customCycleTime) return;
+
+    this.assignNewColorPermutation();
+  }
+
+  tick(): LightsGroup {
+    super.tick();
+
+    if (
+      this.props.customCycleTime &&
+      new Date().getTime() - this.startTick.getTime() > this.props.customCycleTime
+    ) {
+      this.startTick = new Date();
+      this.assignNewColorPermutation();
+    }
+
+    [...this.lightsGroup.pars, ...this.lightsGroup.movingHeadRgbs].forEach((f, i) => {
+      const color = this.props.colors[this.colorIndices[i]];
+      f.fixture.setColor(color);
+    });
+
+    return this.lightsGroup;
+  }
+}

--- a/src/modules/lights/effects/movement/base-rotate.ts
+++ b/src/modules/lights/effects/movement/base-rotate.ts
@@ -2,7 +2,6 @@ import LightsEffect, { BaseLightsEffectProgressionProps } from '../lights-effect
 import { LightsGroup, LightsMovingHeadRgb, LightsMovingHeadWheel } from '../../entities';
 import { EffectProgressionTickStrategy } from '../progression-strategies';
 import { BeatEvent } from '../../../events/music-emitter-events';
-import { LightsEffectDirection, LightsEffectPattern } from '../lights-effect-pattern';
 import EffectProgressionMapFactory from '../progression-strategies/mappers/effect-progression-map-factory';
 
 export interface BaseRotateProps {
@@ -11,8 +10,8 @@ export interface BaseRotateProps {
    * @isInt must be an integer
    * @minimum 0 must be positive
    */
-
   cycleTime?: number;
+
   /**
    * What phase the lights should move apart from each other. 0 for synchronous
    */

--- a/src/modules/lights/effects/movement/classic-rotate.ts
+++ b/src/modules/lights/effects/movement/classic-rotate.ts
@@ -27,8 +27,8 @@ export default class ClassicRotate extends BaseRotate<ClassicRotateProps> {
     super(
       lightsGroup,
       {
-        cycleTime: DEFAULT_CYCLE_TIME,
-        offsetFactor: DEFAULT_OFFSET_FACTOR,
+        cycleTime: props.cycleTime || DEFAULT_CYCLE_TIME,
+        offsetFactor: props.offsetFactor || DEFAULT_OFFSET_FACTOR,
       },
       { pattern: props.pattern, direction: props.direction },
     );

--- a/src/modules/lights/effects/movement/index.ts
+++ b/src/modules/lights/effects/movement/index.ts
@@ -3,19 +3,22 @@ import RandomPosition, { RandomPositionCreateParams } from './random-position';
 import TableRotate, { TableRotateCreateParams } from './table-rotate';
 import FixedPosition, { FixedPositionCreateParams } from './fixed-position';
 import ClassicRotate, { ClassicRotateCreateParams } from './classic-rotate';
+import ZigZag, { ZigZagCreateParams } from './zig-zag';
 
 export { default as SearchLight } from './search-light';
 export { default as TableRotate } from './table-rotate';
 export { default as ClassicRotate } from './classic-rotate';
 export { default as RandomPosition } from './random-position';
 export { default as FixedPosition } from './fixed-position';
+export { default as ZigZag } from './zig-zag';
 
 export type LightsEffectsMovementCreateParams =
   | SearchLightCreateParams
   | TableRotateCreateParams
   | ClassicRotateCreateParams
   | RandomPositionCreateParams
-  | FixedPositionCreateParams;
+  | FixedPositionCreateParams
+  | ZigZagCreateParams;
 
 export const LIGHTS_EFFECTS_MOVEMENT = [
   SearchLight,
@@ -23,4 +26,5 @@ export const LIGHTS_EFFECTS_MOVEMENT = [
   ClassicRotate,
   RandomPosition,
   FixedPosition,
+  ZigZag,
 ];

--- a/src/modules/lights/effects/movement/movement-effetcs.ts
+++ b/src/modules/lights/effects/movement/movement-effetcs.ts
@@ -4,4 +4,5 @@ export enum MovementEffects {
   ClassicRotate = 'ClassicRotate',
   RandomPosition = 'RandomPosition',
   FixedPosition = 'FixedPosition',
+  ZigZag = 'ZigZag',
 }

--- a/src/modules/lights/effects/movement/search-light.ts
+++ b/src/modules/lights/effects/movement/search-light.ts
@@ -36,8 +36,8 @@ export default class SearchLight extends BaseRotate<SearchLightProps> {
     super(
       lightsGroup,
       {
-        cycleTime: DEFAULT_CYCLE_TIME,
-        offsetFactor: DEFAULT_OFFSET_FACTOR,
+        cycleTime: props.cycleTime || DEFAULT_CYCLE_TIME,
+        offsetFactor: props.offsetFactor || DEFAULT_OFFSET_FACTOR,
       },
       { pattern: props.pattern, direction: props.direction },
     );

--- a/src/modules/lights/effects/movement/table-rotate.ts
+++ b/src/modules/lights/effects/movement/table-rotate.ts
@@ -25,7 +25,10 @@ export default class TableRotate extends BaseRotate<TableRotateProps> {
   constructor(lightsGroup: LightsGroup, props: TableRotateProps) {
     super(
       lightsGroup,
-      { cycleTime: DEFAULT_CYCLE_TIME, offsetFactor: DEFAULT_OFFSET_FACTOR },
+      {
+        cycleTime: props.cycleTime || DEFAULT_CYCLE_TIME,
+        offsetFactor: props.offsetFactor || DEFAULT_OFFSET_FACTOR,
+      },
       { pattern: props.pattern, direction: props.direction },
     );
     this.props = props;

--- a/src/modules/lights/effects/movement/zig-zag.ts
+++ b/src/modules/lights/effects/movement/zig-zag.ts
@@ -1,0 +1,69 @@
+import BaseRotate, { BaseRotateProps } from './base-rotate';
+import {
+  BaseLightsEffectCreateParams,
+  BaseLightsEffectProgressionProps,
+  LightsEffectBuilder,
+} from '../lights-effect';
+import { MovementEffects } from './movement-effetcs';
+import { LightsGroup, LightsMovingHeadRgb, LightsMovingHeadWheel } from '../../entities';
+
+export interface ZigZagProps extends BaseRotateProps, BaseLightsEffectProgressionProps {
+  /**
+   * How much the moving head should pan to the left and right
+   */
+  horizontalRadius?: number;
+
+  /**
+   * How much the moving head should tilt up and down
+   */
+  verticalRadius?: number;
+}
+
+export type ZigZagCreateParams = BaseLightsEffectCreateParams & {
+  type: MovementEffects.ZigZag;
+  props: ZigZagProps;
+};
+
+const DEFAULT_HOZ_RADIUS_FACTOR = 0.5;
+const DEFAULT_VERT_RADIUS_FACTOR = 0.8;
+const DEFAULT_CYCLE_TIME = 20000;
+const DEFAULT_OFFSET_FACTOR = 0.25;
+
+export default class ZigZag extends BaseRotate<ZigZagProps> {
+  constructor(lightsGroup: LightsGroup, props: ZigZagProps) {
+    super(
+      lightsGroup,
+      {
+        cycleTime: props.cycleTime || DEFAULT_CYCLE_TIME,
+        offsetFactor: props.offsetFactor || DEFAULT_OFFSET_FACTOR,
+      },
+      {
+        pattern: props.pattern,
+        direction: props.direction,
+      },
+    );
+
+    this.props = props;
+  }
+
+  public static build(props: ZigZagProps = {}): LightsEffectBuilder<ZigZagProps, ZigZag> {
+    return (lightsGroup: LightsGroup) => new ZigZag(lightsGroup, props);
+  }
+
+  protected setPosition(
+    movingHead: LightsMovingHeadWheel | LightsMovingHeadRgb,
+    progression: number,
+    offset: number,
+  ) {
+    const hozRadiusFactor = this.props.horizontalRadius || DEFAULT_HOZ_RADIUS_FACTOR;
+    const horizontalRadius = hozRadiusFactor / 6;
+    const vertRadiusFactor = this.props.verticalRadius || DEFAULT_VERT_RADIUS_FACTOR;
+    const verticalRadius = 0.5 * vertRadiusFactor;
+
+    const panChannel =
+      Math.sin(progression * 2 * Math.PI + offset) * horizontalRadius + (1 - horizontalRadius / 6);
+    const tiltChannel =
+      Math.sin(progression * 24 * Math.PI + offset) * verticalRadius + (1 - vertRadiusFactor / 2);
+    movingHead.setPositionRel(panChannel, tiltChannel);
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds three new lighting effects:

- Background Pulse: a color effect where all fixtures start with the first color in the props's color list. Then, at a given interval, a subset of these fixtures starts changing towards a different (given) color and back. Only fixtures that are not pulsing, can change to this new color. The intent of this effect is to provide a slow, interesting color change.
- Random color: like BeatFadeOut, but every color change each fixture gets assigned a random color based on a permutation of all fixtures. Works best for LightsGroups with a large number of fixtures.
- ZigZag: a movement effect where the moving heads go back and forth in a vertical motion (tilt). To give some extra dimension, the moving heads also slowly move horizontally (pan).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_