### PR TITLE
fix(lights-effects): crash when setting background pulse without colors

### DIFF
--- a/src/modules/lights/effects/color/background-pulse.ts
+++ b/src/modules/lights/effects/color/background-pulse.ts
@@ -135,13 +135,13 @@ export default class BackgroundPulse extends LightsEffect<BackgroundPulseProps> 
    * @param colorIndex
    * @private
    */
-  private getColor(p: number, colorIndex: number): Required<IColorsRgb> {
-    const baseColor = rgbColorDefinitions[this.props.colors[0]].definition;
+  private getColor(p: number, colorIndex: number): Required<IColorsRgb> | undefined {
+    const baseColor = rgbColorDefinitions[this.props.colors[0]]?.definition;
     if (p <= 0 || this.props.colors.length < 2) {
       return baseColor;
     }
 
-    const compositeColor = rgbColorDefinitions[this.props.colors[colorIndex]].definition;
+    const compositeColor = rgbColorDefinitions[this.props.colors[colorIndex]]?.definition;
 
     return {
       redChannel: baseColor.redChannel * (1 - p) + compositeColor.redChannel * p,
@@ -172,7 +172,11 @@ export default class BackgroundPulse extends LightsEffect<BackgroundPulseProps> 
       }
 
       const color = this.getColor(p, this.colorIndices[i] + 1);
-      f.fixture.setCustomColor(color);
+      if (color) {
+        f.fixture.setCustomColor(color);
+      } else {
+        f.fixture.resetColor();
+      }
     });
 
     return this.lightsGroup;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Passing a list of empty colors gives `undefined` for the selector color, which causes a crash.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_