### PR TITLE
feat(centurion): add support for the GEWIScobal

### DIFF
--- a/src/modules/lights/entities/colors-rgb.ts
+++ b/src/modules/lights/entities/colors-rgb.ts
@@ -67,6 +67,8 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
   }
 
   public setColor(color?: RgbColor): void {
+    this.valuesUpdatedAt = new Date();
+
     if (!color) {
       this.reset();
       return;
@@ -95,6 +97,8 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
   }
 
   public setCustomColor(color: IColorsRgb): void {
+    this.valuesUpdatedAt = new Date();
+
     const givenColors = Object.keys(color) as (keyof IColorsRgb)[];
     givenColors.forEach((key: keyof IColorsRgb) => {
       this.currentValues[key] = color[key]!;
@@ -102,6 +106,8 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
   }
 
   public reset(): void {
+    this.valuesUpdatedAt = new Date();
+
     this.setBrightness(1);
     this.currentValues = {
       redChannel: 0,

--- a/src/modules/lights/entities/colors-wheel.ts
+++ b/src/modules/lights/entities/colors-wheel.ts
@@ -48,6 +48,8 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
   };
 
   public setColor(color?: RgbColor): void {
+    this.valuesUpdatedAt = new Date();
+
     if (!color) {
       this.reset();
       return;
@@ -64,6 +66,8 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
   }
 
   public setGobo(gobo?: string) {
+    this.valuesUpdatedAt = new Date();
+
     const channelValueObj = this.goboChannelValues.find((v) => v.name === gobo);
     this.currentValues = {
       ...this.currentValues,
@@ -72,6 +76,8 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
   }
 
   public setGoboRotate(rotate?: string) {
+    this.valuesUpdatedAt = new Date();
+
     const channelValueObj = this.goboRotateChannelValues.find((v) => v.name === rotate);
     this.currentValues = {
       ...this.currentValues,
@@ -80,6 +86,8 @@ export default class ColorsWheel extends Colors implements IColorsWheel {
   }
 
   public reset(): void {
+    this.valuesUpdatedAt = new Date();
+
     this.setBrightness(1);
     this.currentColor = undefined;
     this.currentValues = {

--- a/src/modules/lights/entities/colors.ts
+++ b/src/modules/lights/entities/colors.ts
@@ -2,6 +2,8 @@ import { RgbColor } from '../color-definitions';
 import LightsFixtureShutterOptions from './lights-fixture-shutter-options';
 
 export default abstract class Colors {
+  protected valuesUpdatedAt = new Date();
+
   protected currentBrightness: number = 1;
 
   protected strobe: boolean = false;
@@ -16,6 +18,7 @@ export default abstract class Colors {
    * @param brightness Value between [0, 1]
    */
   public setBrightness(brightness: number) {
+    this.valuesUpdatedAt = new Date();
     // Set upper and lower bounds to 1 and 0 respectively
     this.currentBrightness = Math.max(0, Math.min(1, brightness));
   }
@@ -26,6 +29,7 @@ export default abstract class Colors {
    * be disabled.
    */
   public enableStrobe(milliseconds?: number): void {
+    this.valuesUpdatedAt = new Date();
     this.strobe = true;
 
     // Stop an existing stop strobe timeout if it exists
@@ -44,6 +48,7 @@ export default abstract class Colors {
    * Stop strobe if strobing
    */
   public disableStrobe(): void {
+    this.valuesUpdatedAt = new Date();
     this.strobe = false;
 
     if (this.strobeDisableEvent) {
@@ -57,6 +62,13 @@ export default abstract class Colors {
    */
   public strobeEnabled(): boolean {
     return this.strobe;
+  }
+
+  /**
+   * When the colors have changed
+   */
+  public lastUpdate(): Date {
+    return this.valuesUpdatedAt;
   }
 
   /**

--- a/src/modules/lights/entities/lights-fixture.ts
+++ b/src/modules/lights/entities/lights-fixture.ts
@@ -57,6 +57,13 @@ export default abstract class LightsFixture extends BaseEntity {
     return true;
   }
 
+  protected getMaxDate(...dates: Date[]): Date {
+    const times = dates.map((d) => d.getTime());
+    const maxTime = Math.max(...times);
+    return new Date(maxTime);
+  }
+  public abstract lastUpdate(): Date;
+
   public abstract setColor(color: RgbColor): void;
   public abstract resetColor(): void;
 

--- a/src/modules/lights/entities/lights-moving-head-rgb.ts
+++ b/src/modules/lights/entities/lights-moving-head-rgb.ts
@@ -13,18 +13,23 @@ export default class LightsMovingHeadRgb extends LightsMovingHead {
   @Column(() => ColorsRgb)
   public color: ColorsRgb;
 
+  public lastUpdate(): Date {
+    return this.getMaxDate(
+      this.valuesUpdatedAt,
+      this.color.lastUpdate(),
+      this.movement.lastUpdate(),
+    );
+  }
+
   public setColor(color?: RgbColor) {
-    this.valuesUpdatedAt = new Date();
     this.color.setColor(color);
   }
 
   public setCustomColor(color: IColorsRgb) {
-    this.valuesUpdatedAt = new Date();
     this.color.setCustomColor(color);
   }
 
   public resetColor() {
-    this.valuesUpdatedAt = new Date();
     this.color.reset();
   }
 
@@ -34,17 +39,14 @@ export default class LightsMovingHeadRgb extends LightsMovingHead {
   }
 
   public enableStrobe(milliseconds?: number): void {
-    this.valuesUpdatedAt = new Date();
     this.color.enableStrobe(milliseconds);
   }
 
   public disableStrobe(): void {
-    this.valuesUpdatedAt = new Date();
     this.color.disableStrobe();
   }
 
   public setBrightness(brightness: number): void {
-    this.valuesUpdatedAt = new Date();
     this.color.setBrightness(brightness);
   }
 

--- a/src/modules/lights/entities/lights-moving-head-wheel.ts
+++ b/src/modules/lights/entities/lights-moving-head-wheel.ts
@@ -12,23 +12,27 @@ export default class LightsMovingHeadWheel extends LightsMovingHead {
   @Column(() => ColorsWheel)
   public wheel: ColorsWheel;
 
+  public lastUpdate(): Date {
+    return this.getMaxDate(
+      this.valuesUpdatedAt,
+      this.wheel.lastUpdate(),
+      this.movement.lastUpdate(),
+    );
+  }
+
   public setColor(color?: RgbColor) {
-    this.valuesUpdatedAt = new Date();
     this.wheel.setColor(color);
   }
 
   public resetColor(): void {
-    this.valuesUpdatedAt = new Date();
     this.wheel.reset();
   }
 
   public setGobo(gobo?: string) {
-    this.valuesUpdatedAt = new Date();
     this.wheel.setGobo(gobo);
   }
 
   public setGoboRotate(rotate?: string) {
-    this.valuesUpdatedAt = new Date();
     this.wheel.setGoboRotate(rotate);
   }
 
@@ -38,17 +42,14 @@ export default class LightsMovingHeadWheel extends LightsMovingHead {
   }
 
   public enableStrobe(milliseconds?: number): void {
-    this.valuesUpdatedAt = new Date();
     this.wheel.enableStrobe(milliseconds);
   }
 
   public disableStrobe(): void {
-    this.valuesUpdatedAt = new Date();
     this.wheel.disableStrobe();
   }
 
   public setBrightness(brightness: number): void {
-    this.valuesUpdatedAt = new Date();
     this.wheel.setBrightness(brightness);
   }
 

--- a/src/modules/lights/entities/lights-moving-head.ts
+++ b/src/modules/lights/entities/lights-moving-head.ts
@@ -11,7 +11,6 @@ export default abstract class LightsMovingHead extends LightsFixture {
    * @param tilt value between [0, 1]
    */
   public setPositionRel(pan: number, tilt: number) {
-    this.valuesUpdatedAt = new Date();
     this.movement.setPositionRel(pan, tilt);
   }
 
@@ -21,12 +20,10 @@ export default abstract class LightsMovingHead extends LightsFixture {
    * @deprecated
    */
   public setPosition(pan: number, tilt: number) {
-    this.valuesUpdatedAt = new Date();
     this.movement.setPositionAbs(pan, tilt);
   }
 
   protected setPositionInDmx(values: number[]): number[] {
-    this.valuesUpdatedAt = new Date();
     return this.movement.setPositionInDmx(values);
   }
 

--- a/src/modules/lights/entities/lights-par.ts
+++ b/src/modules/lights/entities/lights-par.ts
@@ -13,18 +13,19 @@ export default class LightsPar extends LightsFixture {
   @Column(() => ColorsRgb)
   public color: ColorsRgb;
 
+  public lastUpdate(): Date {
+    return this.getMaxDate(this.valuesUpdatedAt, this.color.lastUpdate());
+  }
+
   public setColor(color?: RgbColor) {
-    this.valuesUpdatedAt = new Date();
     this.color.setColor(color);
   }
 
   public setCustomColor(color: IColorsRgb) {
-    this.valuesUpdatedAt = new Date();
     this.color.setCustomColor(color);
   }
 
   public resetColor() {
-    this.valuesUpdatedAt = new Date();
     this.color.reset();
   }
 
@@ -34,17 +35,14 @@ export default class LightsPar extends LightsFixture {
   }
 
   public enableStrobe(milliseconds?: number): void {
-    this.valuesUpdatedAt = new Date();
     this.color.enableStrobe(milliseconds);
   }
 
   public disableStrobe(): void {
-    this.valuesUpdatedAt = new Date();
     this.color.disableStrobe();
   }
 
   public setBrightness(brightness: number): void {
-    this.valuesUpdatedAt = new Date();
     this.color.setBrightness(brightness);
   }
 

--- a/src/modules/lights/entities/movement.ts
+++ b/src/modules/lights/entities/movement.ts
@@ -27,6 +27,8 @@ export default class Movement implements IMovement {
   @Column({ type: 'tinyint', nullable: true, unsigned: true })
   public movingSpeedChannel?: number | null;
 
+  private valuesUpdatedAt = new Date();
+
   private currentValues: Required<IMovement> = {
     panChannel: 0,
     finePanChannel: 0,
@@ -36,10 +38,19 @@ export default class Movement implements IMovement {
   };
 
   /**
+   * When the moving head's position has last changed
+   */
+  public lastUpdate(): Date {
+    return this.valuesUpdatedAt;
+  }
+
+  /**
    * @param panFactor value between [0, 1]
    * @param tiltFactor value between [0, 1]
    */
   public setPositionRel(panFactor: number, tiltFactor: number) {
+    this.valuesUpdatedAt = new Date();
+
     const pan = panFactor * 170;
     const tilt = tiltFactor * 255;
     const panChannel = Math.floor(pan) + this.basePanValue;
@@ -62,6 +73,8 @@ export default class Movement implements IMovement {
    * @deprecated
    */
   public setPositionAbs(pan: number, tilt: number) {
+    this.valuesUpdatedAt = new Date();
+
     const panChannel = Math.floor(pan);
     const tiltChannel = Math.floor(tilt);
     const finePanChannel = Math.floor((pan - panChannel) * 255);
@@ -80,6 +93,8 @@ export default class Movement implements IMovement {
    * Reset the moving head to its initial position
    */
   public reset() {
+    this.valuesUpdatedAt = new Date();
+
     this.currentValues = {
       panChannel: 0,
       finePanChannel: 0,

--- a/src/modules/modes/centurion/centurion-mode.ts
+++ b/src/modules/modes/centurion/centurion-mode.ts
@@ -1,5 +1,5 @@
 import BaseMode from '../base-mode';
-import { LightsGroup } from '../../lights/entities';
+import { LightsGroup, LightsSwitch } from '../../lights/entities';
 import { Audio, Screen } from '../../root/entities';
 import SetEffectsHandler from '../../handlers/lights/set-effects-handler';
 import SimpleAudioHandler from '../../handlers/audio/simple-audio-handler';
@@ -15,18 +15,25 @@ import Wave from '../../lights/effects/color/wave';
 import Sparkle from '../../lights/effects/color/sparkle';
 import { ArtificialBeatGenerator } from '../../beats/artificial-beat-generator';
 import logger from '../../../logger';
+import LightsSwitchManager from '../../root/lights-switch-manager';
+import { FeatureEnabled, ServerSettingsStore } from '../../server-settings';
+import { ISettings } from '../../server-settings/server-setting';
+import RootLightsService from '../../root/root-lights-service';
 
 const LIGHTS_HANDLER = 'SetEffectsHandler';
 const AUDIO_HANDLER = 'SimpleAudioHandler';
 const SCREEN_HANDLER = 'CenturionScreenHandler';
 const STROBE_TIME = 1500; // Milliseconds
 
+@FeatureEnabled('Centurion')
 export default class CenturionMode extends BaseMode<
   SetEffectsHandler,
   CenturionScreenHandler,
   SimpleAudioHandler
 > {
   public tape: MixTape;
+
+  private discoballs: LightsSwitch[] = [];
 
   private musicEmitter: MusicEmitter;
 
@@ -47,6 +54,8 @@ export default class CenturionMode extends BaseMode<
 
   private beatGenerator: ArtificialBeatGenerator;
 
+  private lightsSwitchManager: LightsSwitchManager;
+
   private initialized = false;
 
   public get playing(): boolean {
@@ -61,9 +70,24 @@ export default class CenturionMode extends BaseMode<
     this.beatGenerator = ArtificialBeatGenerator.getInstance();
   }
 
-  public initialize(musicEmitter: MusicEmitter) {
+  public async initialize(musicEmitter: MusicEmitter) {
     if (this.initialized) throw new Error('CenturionMode already initialized!');
     this.musicEmitter = musicEmitter;
+    this.lightsSwitchManager = LightsSwitchManager.getInstance();
+
+    const discoballIds = ServerSettingsStore.getInstance().getSetting(
+      'Centurion.DiscoballLightsSwitchIds',
+    ) as ISettings['Centurion.DiscoballLightsSwitchIds'];
+    this.discoballs = (await new RootLightsService().getAllLightsSwitches()).filter((s) =>
+      discoballIds.includes(s.id),
+    );
+
+    // Disable the disco balls if they are enabled
+    this.lightsSwitchManager.getEnabledSwitches().forEach((s) => {
+      if (discoballIds.includes(s.id)) {
+        this.lightsSwitchManager.disableSwitch(s);
+      }
+    });
   }
 
   public loadTape(tape: MixTape) {
@@ -118,6 +142,14 @@ export default class CenturionMode extends BaseMode<
     logger.info('Paused centurion playback.');
 
     this.timestamp = (new Date().getTime() - this.startTime.getTime()) / 1000;
+  }
+
+  /**
+   * Returns whether a disco ball is present in the centurion lights setup
+   * @private
+   */
+  private hasDiscoBall(): boolean {
+    return this.discoballs.length > 0;
   }
 
   /**
@@ -283,6 +315,18 @@ export default class CenturionMode extends BaseMode<
       this.setRandomLightEffects();
       this.emitSong(event.data);
     } else if (event.type === 'effect') {
+      const isEffectDisableAll =
+        event.data.effects.pars &&
+        event.data.effects.pars.length === 0 &&
+        event.data.effects.movingHeadRgbColor &&
+        event.data.effects.movingHeadRgbColor.length === 0 &&
+        event.data.effects.movingHeadRgbMovement &&
+        event.data.effects.movingHeadRgbMovement.length === 0 &&
+        event.data.effects.movingHeadWheelColor &&
+        event.data.effects.movingHeadWheelColor.length === 0 &&
+        event.data.effects.movingHeadWheelMovement &&
+        event.data.effects.movingHeadWheelMovement.length === 0;
+
       this.lights.forEach((l) => {
         if (event.data.reset) {
           // Reset effect
@@ -293,6 +337,22 @@ export default class CenturionMode extends BaseMode<
         if (event.data.random) {
           this.setRandomLightEffects();
           return;
+        }
+        if (event.data.effects.discoBall && isEffectDisableAll && !this.hasDiscoBall()) {
+          // If we want to only have the disco ball turned on, but our setup does not have one,
+          // we should just do random light effects
+          this.setRandomLightEffects();
+          return;
+        }
+        if (event.data.effects.discoBall) {
+          this.discoballs.forEach((s) => {
+            this.lightsSwitchManager.enableSwitch(s);
+          });
+        } else if (this.hasDiscoBall()) {
+          // Disable all disco balls if they should not be enabled
+          this.discoballs.forEach((s) => {
+            this.lightsSwitchManager.disableSwitch(s);
+          });
         }
         if (l.pars.length > 0 && event.data.effects.pars) {
           // Color effect for pars

--- a/src/modules/modes/centurion/centurion-mode.ts
+++ b/src/modules/modes/centurion/centurion-mode.ts
@@ -336,6 +336,10 @@ export default class CenturionMode extends BaseMode<
         }
         if (event.data.random) {
           this.setRandomLightEffects();
+          if (this.beatGenerator.bpm) {
+            // Restart the beat generator to ensure no quick successive beats when the lights change
+            this.beatGenerator.start(this.beatGenerator.bpm);
+          }
           return;
         }
         if (event.data.effects.discoBall && isEffectDisableAll && !this.hasDiscoBall()) {

--- a/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion-2-original.ts
+++ b/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion-2-original.ts
@@ -585,6 +585,21 @@ const centurion2Original: MixTape = {
       ],
     },
     {
+      timestamp: 1752.01,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn on only the disco ball; all other lights should be off.
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
       timestamp: 1815.7,
       type: 'horn',
       data: {
@@ -598,6 +613,39 @@ const centurion2Original: MixTape = {
         artist: 'Pitbull feat. John Ryan',
         title: 'Fireball',
         bpm: 124,
+      },
+    },
+    {
+      timestamp: 1816.01,
+      type: 'effect',
+      data: {
+        effects: {
+          // Override the random change of effects when song changes to
+          // keep on the disco ball turned on
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
+      timestamp: 1839.4,
+      type: 'effect',
+      data: {
+        effects: {
+          discoBall: false,
+        },
+      },
+    },
+    {
+      timestamp: 1841.07,
+      type: 'effect',
+      data: {
+        random: true,
+        effects: {},
       },
     },
     {
@@ -1329,6 +1377,16 @@ const centurion2Original: MixTape = {
       },
     },
     {
+      timestamp: 4100.1,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn on the disco ball; leave other effects intact.
+          discoBall: true,
+        },
+      },
+    },
+    {
       timestamp: 4155.7,
       type: 'horn',
       data: {
@@ -1351,6 +1409,16 @@ const centurion2Original: MixTape = {
         artist: 'Jody Bernal',
         title: 'Que Si, Que No',
         bpm: 135,
+      },
+    },
+    {
+      timestamp: 4178.7,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn off only the disco ball
+          discoBall: false,
+        },
       },
     },
     {
@@ -1575,6 +1643,31 @@ const centurion2Original: MixTape = {
       },
     },
     {
+      timestamp: 4740.0,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn on only the disco ball
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
+      timestamp: 4796.0,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn off the disco ball. The room is now completely black
+          discoBall: false,
+        },
+      },
+    },
+    {
       timestamp: 4796.2,
       type: 'horn',
       data: {
@@ -1689,10 +1782,44 @@ const centurion2Original: MixTape = {
       },
     },
     {
+      timestamp: 5132.0,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn on only the disco ball
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
       timestamp: 5158.9,
       type: 'horn',
       data: {
         counter: 84,
+      },
+    },
+    {
+      timestamp: 5159.0,
+      type: 'effect',
+      data: {
+        // Turn on a random effect. Note that the disco ball is still on
+        random: true,
+        effects: {},
+      },
+    },
+    {
+      timestamp: 5181.6,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn off the disco ball
+          discoBall: false,
+        },
       },
     },
     {

--- a/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion-2-original.ts
+++ b/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion-2-original.ts
@@ -588,9 +588,9 @@ const centurion2Original: MixTape = {
       timestamp: 1752.01,
       type: 'effect',
       data: {
+        // Turn on only the disco ball; all other lights should be off.
+        discoBall: true,
         effects: {
-          // Turn on only the disco ball; all other lights should be off.
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -619,10 +619,10 @@ const centurion2Original: MixTape = {
       timestamp: 1816.01,
       type: 'effect',
       data: {
+        // Override the random change of effects when song changes to
+        // keep on the disco ball turned on
+        discoBall: true,
         effects: {
-          // Override the random change of effects when song changes to
-          // keep on the disco ball turned on
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -635,9 +635,8 @@ const centurion2Original: MixTape = {
       timestamp: 1839.4,
       type: 'effect',
       data: {
-        effects: {
-          discoBall: false,
-        },
+        discoBall: false,
+        effects: {},
       },
     },
     {
@@ -1380,10 +1379,9 @@ const centurion2Original: MixTape = {
       timestamp: 4100.1,
       type: 'effect',
       data: {
-        effects: {
-          // Turn on the disco ball; leave other effects intact.
-          discoBall: true,
-        },
+        // Turn on the disco ball; leave other effects intact.
+        discoBall: true,
+        effects: {},
       },
     },
     {
@@ -1415,10 +1413,9 @@ const centurion2Original: MixTape = {
       timestamp: 4178.7,
       type: 'effect',
       data: {
-        effects: {
-          // Turn off only the disco ball
-          discoBall: false,
-        },
+        // Turn off only the disco ball
+        discoBall: false,
+        effects: {},
       },
     },
     {
@@ -1646,9 +1643,9 @@ const centurion2Original: MixTape = {
       timestamp: 4740.0,
       type: 'effect',
       data: {
+        // Turn on only the disco ball
+        discoBall: true,
         effects: {
-          // Turn on only the disco ball
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -1661,10 +1658,9 @@ const centurion2Original: MixTape = {
       timestamp: 4796.0,
       type: 'effect',
       data: {
-        effects: {
-          // Turn off the disco ball. The room is now completely black
-          discoBall: false,
-        },
+        // Turn off the disco ball. The room is now completely black
+        discoBall: false,
+        effects: {},
       },
     },
     {
@@ -1785,9 +1781,9 @@ const centurion2Original: MixTape = {
       timestamp: 5132.0,
       type: 'effect',
       data: {
+        // Turn on only the disco ball
+        discoBall: true,
         effects: {
-          // Turn on only the disco ball
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -1816,10 +1812,9 @@ const centurion2Original: MixTape = {
       timestamp: 5181.6,
       type: 'effect',
       data: {
-        effects: {
-          // Turn off the disco ball
-          discoBall: false,
-        },
+        // Turn off the disco ball
+        discoBall: false,
+        effects: {},
       },
     },
     {

--- a/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion.ts
+++ b/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion.ts
@@ -286,6 +286,30 @@ const centurion: MixTape = {
       },
     },
     {
+      timestamp: 757.01,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn on only the disco ball; all other lights should be off.
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
+      timestamp: 811.5,
+      type: 'effect',
+      data: {
+        effects: {
+          discoBall: false,
+        },
+      },
+    },
+    {
       timestamp: 811.5,
       type: 'horn',
       data: {
@@ -293,7 +317,7 @@ const centurion: MixTape = {
       },
     },
     {
-      timestamp: 814.0,
+      timestamp: 812.0,
       type: 'song',
       data: {
         artist: 'Guus Meeuwis',
@@ -452,6 +476,25 @@ const centurion: MixTape = {
       type: 'horn',
       data: {
         counter: 21,
+      },
+    },
+    {
+      timestamp: 1288.0,
+      type: 'effect',
+      data: {
+        effects: {
+          // Add the disco ball
+          discoBall: true,
+        },
+      },
+    },
+    {
+      timestamp: 1348.4,
+      type: 'effect',
+      data: {
+        effects: {
+          discoBall: false,
+        },
       },
     },
     {
@@ -1038,6 +1081,29 @@ const centurion: MixTape = {
       },
     },
     {
+      timestamp: 3279.0,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn on only the disco ball; all other lights should be off.
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
+      timestamp: 3318.5,
+      type: 'effect',
+      data: {
+        random: true,
+        effects: {},
+      },
+    },
+    {
       timestamp: 3340.8,
       type: 'horn',
       data: {
@@ -1051,6 +1117,23 @@ const centurion: MixTape = {
         artist: 'Tom Waes',
         title: 'Dos cervezas',
         bpm: 136,
+      },
+    },
+    {
+      timestamp: 3369.8,
+      type: 'effect',
+      data: {
+        effects: {
+          discoBall: false,
+        },
+      },
+    },
+    {
+      timestamp: 3369.8,
+      type: 'effect',
+      data: {
+        random: true,
+        effects: {},
       },
     },
     {
@@ -1619,6 +1702,21 @@ const centurion: MixTape = {
       },
     },
     {
+      timestamp: 5237.01,
+      type: 'effect',
+      data: {
+        effects: {
+          // Turn on only the disco ball; all other lights should be off.
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
       timestamp: 5242.8,
       type: 'horn',
       data: {
@@ -1632,6 +1730,21 @@ const centurion: MixTape = {
         artist: 'Enrique Iglesias',
         title: 'Hero',
         bpm: 76,
+      },
+    },
+    {
+      timestamp: 5278.01,
+      type: 'effect',
+      data: {
+        effects: {
+          // Keep the disco ball turned on; all other lights should be off.
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
       },
     },
     {
@@ -1651,6 +1764,21 @@ const centurion: MixTape = {
       },
     },
     {
+      timestamp: 5331.01,
+      type: 'effect',
+      data: {
+        effects: {
+          // Keep the disco ball turned on; all other lights should be off.
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
       timestamp: 5373.85,
       type: 'horn',
       data: {
@@ -1658,12 +1786,29 @@ const centurion: MixTape = {
       },
     },
     {
-      timestamp: 5380.0,
+      timestamp: 5373.85,
+      type: 'effect',
+      data: {
+        effects: {
+          discoBall: false,
+        },
+      },
+    },
+    {
+      timestamp: 5373.9,
       type: 'song',
       data: {
         artist: 'Mariah Carey',
         title: 'All I Want For Christmas',
         bpm: 151,
+      },
+    },
+    {
+      timestamp: 5380.0,
+      type: 'effect',
+      data: {
+        random: true,
+        effects: {},
       },
     },
     {
@@ -1857,6 +2002,21 @@ const centurion: MixTape = {
       },
     },
     {
+      timestamp: 5970.0,
+      type: 'effect',
+      data: {
+        effects: {
+          // Keep the disco ball turned on; all other lights should be off.
+          discoBall: true,
+          pars: [],
+          movingHeadRgbColor: [],
+          movingHeadRgbMovement: [],
+          movingHeadWheelColor: [],
+          movingHeadWheelMovement: [],
+        },
+      },
+    },
+    {
       timestamp: 6020.3,
       type: 'horn',
       data: {
@@ -1869,6 +2029,7 @@ const centurion: MixTape = {
       type: 'effect',
       data: {
         effects: {
+          discoBall: false,
           pars: [Fire.build()],
           movingHeadWheelColor: [StaticColor.build({ color: RgbColor.BLINDINGWHITE })],
           movingHeadWheelMovement: [SearchLight.build({ cycleTime: 20000, radiusFactor: 1.5 })],

--- a/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion.ts
+++ b/src/modules/modes/centurion/tapes/gebroeders-scooter-centurion.ts
@@ -286,30 +286,6 @@ const centurion: MixTape = {
       },
     },
     {
-      timestamp: 757.01,
-      type: 'effect',
-      data: {
-        effects: {
-          // Turn on only the disco ball; all other lights should be off.
-          discoBall: true,
-          pars: [],
-          movingHeadRgbColor: [],
-          movingHeadRgbMovement: [],
-          movingHeadWheelColor: [],
-          movingHeadWheelMovement: [],
-        },
-      },
-    },
-    {
-      timestamp: 811.5,
-      type: 'effect',
-      data: {
-        effects: {
-          discoBall: false,
-        },
-      },
-    },
-    {
       timestamp: 811.5,
       type: 'horn',
       data: {
@@ -482,19 +458,17 @@ const centurion: MixTape = {
       timestamp: 1288.0,
       type: 'effect',
       data: {
-        effects: {
-          // Add the disco ball
-          discoBall: true,
-        },
+        // Add the disco ball
+        discoBall: true,
+        effects: {},
       },
     },
     {
       timestamp: 1348.4,
       type: 'effect',
       data: {
-        effects: {
-          discoBall: false,
-        },
+        discoBall: false,
+        effects: {},
       },
     },
     {
@@ -1084,9 +1058,9 @@ const centurion: MixTape = {
       timestamp: 3279.0,
       type: 'effect',
       data: {
+        // Turn on only the disco ball; all other lights should be off.
+        discoBall: true,
         effects: {
-          // Turn on only the disco ball; all other lights should be off.
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -1123,9 +1097,8 @@ const centurion: MixTape = {
       timestamp: 3369.8,
       type: 'effect',
       data: {
-        effects: {
-          discoBall: false,
-        },
+        discoBall: false,
+        effects: {},
       },
     },
     {
@@ -1705,9 +1678,9 @@ const centurion: MixTape = {
       timestamp: 5237.01,
       type: 'effect',
       data: {
+        // Turn on only the disco ball; all other lights should be off.
+        discoBall: true,
         effects: {
-          // Turn on only the disco ball; all other lights should be off.
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -1736,9 +1709,9 @@ const centurion: MixTape = {
       timestamp: 5278.01,
       type: 'effect',
       data: {
+        // Keep the disco ball turned on; all other lights should be off.
+        discoBall: true,
         effects: {
-          // Keep the disco ball turned on; all other lights should be off.
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -1767,9 +1740,9 @@ const centurion: MixTape = {
       timestamp: 5331.01,
       type: 'effect',
       data: {
+        // Keep the disco ball turned on; all other lights should be off.
+        discoBall: true,
         effects: {
-          // Keep the disco ball turned on; all other lights should be off.
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -1789,9 +1762,8 @@ const centurion: MixTape = {
       timestamp: 5373.85,
       type: 'effect',
       data: {
-        effects: {
-          discoBall: false,
-        },
+        discoBall: false,
+        effects: {},
       },
     },
     {
@@ -2005,9 +1977,9 @@ const centurion: MixTape = {
       timestamp: 5970.0,
       type: 'effect',
       data: {
+        discoBall: true,
         effects: {
           // Keep the disco ball turned on; all other lights should be off.
-          discoBall: true,
           pars: [],
           movingHeadRgbColor: [],
           movingHeadRgbMovement: [],
@@ -2028,8 +2000,8 @@ const centurion: MixTape = {
       timestamp: 6021,
       type: 'effect',
       data: {
+        discoBall: false,
         effects: {
-          discoBall: false,
           pars: [Fire.build()],
           movingHeadWheelColor: [StaticColor.build({ color: RgbColor.BLINDINGWHITE })],
           movingHeadWheelMovement: [SearchLight.build({ cycleTime: 20000, radiusFactor: 1.5 })],

--- a/src/modules/modes/centurion/tapes/mix-tape.ts
+++ b/src/modules/modes/centurion/tapes/mix-tape.ts
@@ -44,9 +44,10 @@ export type EffectData = {
     movingHeadWheelColor?: LightsEffectBuilder[];
     movingHeadWheelMovement?: LightsEffectBuilder[];
     /**
-     * Whether the disco ball should be enabled. Will be disabled by default
+     * Whether the disco ball should be enabled. Must be manually turned off, this will not
+     * happen when changing to a random effect. Defaults to false (turn off the disco ball).
      */
-    discoBall?: true;
+    discoBall?: boolean;
   };
 };
 

--- a/src/modules/modes/centurion/tapes/mix-tape.ts
+++ b/src/modules/modes/centurion/tapes/mix-tape.ts
@@ -34,7 +34,8 @@ export type EffectData = {
    */
   random?: boolean;
   /**
-   * Set custom effects
+   * Set custom effects. If an attribute is absent, this type of effect will not be applied.
+   * If an attribute is present with an empty array, this type of effect will be disabled.
    */
   effects: {
     pars?: LightsEffectBuilder[];
@@ -42,6 +43,10 @@ export type EffectData = {
     movingHeadRgbMovement?: LightsEffectBuilder[];
     movingHeadWheelColor?: LightsEffectBuilder[];
     movingHeadWheelMovement?: LightsEffectBuilder[];
+    /**
+     * Whether the disco ball should be enabled. Will be disabled by default
+     */
+    discoBall?: true;
   };
 };
 

--- a/src/modules/modes/centurion/tapes/mix-tape.ts
+++ b/src/modules/modes/centurion/tapes/mix-tape.ts
@@ -26,6 +26,11 @@ export type Song = {
 
 export type EffectData = {
   /**
+   * Whether the disco ball should be enabled. Must be manually turned off, this will not
+   * happen when changing to a random effect. Defaults to false (turn off the disco ball).
+   */
+  discoBall?: boolean;
+  /**
    * Disable all lights (overrides effects and random)
    */
   reset?: boolean;
@@ -43,11 +48,6 @@ export type EffectData = {
     movingHeadRgbMovement?: LightsEffectBuilder[];
     movingHeadWheelColor?: LightsEffectBuilder[];
     movingHeadWheelMovement?: LightsEffectBuilder[];
-    /**
-     * Whether the disco ball should be enabled. Must be manually turned off, this will not
-     * happen when changing to a random effect. Defaults to false (turn off the disco ball).
-     */
-    discoBall?: boolean;
   };
 };
 

--- a/src/modules/modes/mode-controller.ts
+++ b/src/modules/modes/mode-controller.ts
@@ -84,7 +84,7 @@ export class ModeController extends Controller {
     const { lights, screens, audios } = await this.mapBodyToEntities(params);
 
     const centurionMode = new CenturionMode(lights, screens, audios);
-    centurionMode.initialize(this.modeManager.musicEmitter);
+    await centurionMode.initialize(this.modeManager.musicEmitter);
     const tape = tapes.find((t) => {
       return t.name === params.centurionName && t.artist === params.centurionArtist;
     });

--- a/src/modules/modes/mode-controller.ts
+++ b/src/modules/modes/mode-controller.ts
@@ -50,8 +50,8 @@ export class ModeController extends Controller {
 
   private async mapBodyToEntities(params: EnableModeParams) {
     const lights = (await this.findEntities(LightsGroup, params.lightsGroupIds)) as LightsGroup[];
-    const screens = (await this.findEntities(Screen, params.lightsGroupIds)) as Screen[];
-    const audios = (await this.findEntities(Audio, params.lightsGroupIds)) as Audio[];
+    const screens = (await this.findEntities(Screen, params.screenIds)) as Screen[];
+    const audios = (await this.findEntities(Audio, params.audioIds)) as Audio[];
 
     return { lights, screens, audios };
   }

--- a/src/modules/modes/mode-settings.ts
+++ b/src/modules/modes/mode-settings.ts
@@ -1,9 +1,23 @@
 export interface ModeSettings {
+  /**
+   * Whether Centurion Mode should be available/present.
+   */
   Centurion: boolean;
+
+  /**
+   * IDs of all light switches that should be activated when a discoball
+   * should be turned on.
+   */
+  'Centurion.DiscoballLightsSwitchIds': number[];
+
+  /**
+   * Whether Time Trail Race (Spoelbakkenrace) should be available/present.
+   */
   TimeTrailRace: boolean;
 }
 
 export const ModeSettingsDefaults: ModeSettings = {
   Centurion: true,
+  'Centurion.DiscoballLightsSwitchIds': [],
   TimeTrailRace: true,
 };

--- a/src/modules/root/lights-controller-manager.ts
+++ b/src/modules/root/lights-controller-manager.ts
@@ -172,7 +172,7 @@ export default class LightsControllerManager {
    * @param valuesUpdatedAt
    * @private
    */
-  private hasUpdated(valuesUpdatedAt?: Date) {
+  private hasUpdated(valuesUpdatedAt?: Date): boolean {
     if (valuesUpdatedAt === undefined) return true;
     return valuesUpdatedAt > this.previousTick;
   }
@@ -202,7 +202,7 @@ export default class LightsControllerManager {
 
       g.pars.forEach((p) => {
         // Only update fixture in packet if it is in a new state (and thus needs to be updated)
-        if (this.hasUpdated(p.fixture.valuesUpdatedAt)) {
+        if (this.hasUpdated(p.fixture.lastUpdate())) {
           newValues = this.calculateNewDmxValues(p, newValues);
         } else {
           newValues = this.reuseOldDmxValues(p, oldValues, newValues);
@@ -211,7 +211,7 @@ export default class LightsControllerManager {
 
       g.movingHeadRgbs.forEach((p) => {
         // Only update fixture in packet if it is in a new state (and thus needs to be updated)
-        if (this.hasUpdated(p.fixture.valuesUpdatedAt)) {
+        if (this.hasUpdated(p.fixture.lastUpdate())) {
           newValues = this.calculateNewDmxValues(p, newValues);
         } else {
           newValues = this.reuseOldDmxValues(p, oldValues, newValues);
@@ -220,7 +220,7 @@ export default class LightsControllerManager {
 
       g.movingHeadWheels.forEach((p) => {
         // Only update fixture in packet if it is in a new state (and thus needs to be updated)
-        if (this.hasUpdated(p.fixture.valuesUpdatedAt)) {
+        if (this.hasUpdated(p.fixture.lastUpdate())) {
           newValues = this.calculateNewDmxValues(p, newValues);
         } else {
           newValues = this.reuseOldDmxValues(p, oldValues, newValues);

--- a/src/modules/server-settings/feature-enabled.ts
+++ b/src/modules/server-settings/feature-enabled.ts
@@ -74,7 +74,7 @@ export default function FeatureEnabled(setting: keyof ISettings): ClassDecorator
             throw new Error(`Class "${constr.name}" is disabled by setting "${setting}"`);
           }
 
-          super(constructorArgs);
+          super(...constructorArgs);
         }
       };
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds support for the GEWIScobal in Centurion 1 and 2.

Also includes several fixes:
- A fix for setting a lightsgroup to strobe for a fixed amount of time, without having any other effects playing in the background. The lights would infinitely strobe until an effect would be applied. This bug was not (visibly) present in any centurion tapes.
- A fix that enabling a mode would not be possible without any lights.
- A fix for using the `@FeatureEnabled()` decorator with classes and constructor parameters.


## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_