### PR TITLE
feat: add integration users to allow other services to integrate with Aurora

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import ServerSetting from './modules/server-settings/server-setting';
 import { Entities as BaseEntities } from './modules/root/entities';
 import { Entities as AuthEntities } from './modules/auth/entities';
+import { Entities as IntegrationEntities } from './modules/auth/integration/entities';
 import { Entities as FileEntities } from './modules/files/entities';
 import { Entities as AuditEntities } from './modules/audit/entities';
 import { Entities as SpotifyEntities } from './modules/spotify/entities';
@@ -36,6 +37,7 @@ const dataSource = new DataSource({
     ...TimedEventsEntities,
     ...BaseEntities,
     ...AuthEntities,
+    ...IntegrationEntities,
     ...FileEntities,
     ...AuditEntities,
     ...SpotifyEntities,

--- a/src/helpers/security-groups.ts
+++ b/src/helpers/security-groups.ts
@@ -28,6 +28,7 @@ export interface ISecurityGroups {
   serverSettings: ISecuritySections;
   orders: ISecuritySections;
   timedEvents: ISecuritySections;
+  integrationUsers: ISecuritySections;
 }
 
 /**
@@ -150,6 +151,9 @@ export const securityGroups = {
   },
   timedEvents: {
     base: allSecurityGroups,
+    privileged: [SecurityGroup.ADMIN],
+  },
+  integrationUsers: {
     privileged: [SecurityGroup.ADMIN],
   },
 };

--- a/src/helpers/security.ts
+++ b/src/helpers/security.ts
@@ -14,6 +14,7 @@ export enum SecurityGroup {
 
 export enum SecurityNames {
   LOCAL = 'local',
+  INTEGRATION = 'integration',
 }
 
 /**

--- a/src/http.ts
+++ b/src/http.ts
@@ -10,6 +10,7 @@ import apiDocs from '../build/swagger.json';
 import { SessionMiddleware, apiKeyMiddleware } from './modules/auth';
 import { setupErrorHandler } from './error';
 import { authResponse } from './modules/auth/passport';
+import { IntegrationUserActivityMiddleware } from './modules/auth/integration';
 
 const origins = process.env.CORS_ORIGINS?.split(', ');
 export const enableCors = origins !== undefined && origins.length > 0;
@@ -59,10 +60,12 @@ export default async function createHttp() {
   app.use(bodyParser.json());
   app.use(cookieParser(process.env.COOKIE_SECRET));
   app.use(SessionMiddleware.getInstance().get());
-  app.use(apiKeyMiddleware);
 
   app.use(passport.initialize());
   app.use(passport.session());
+
+  app.use(apiKeyMiddleware);
+  app.use(IntegrationUserActivityMiddleware);
 
   RegisterRoutes(app);
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -7,7 +7,7 @@ import passport from 'passport';
 import { pinoHttp } from 'pino-http';
 import { RegisterRoutes } from '../build/routes';
 import apiDocs from '../build/swagger.json';
-import { SessionMiddleware } from './modules/auth';
+import { SessionMiddleware, apiKeyMiddleware } from './modules/auth';
 import { setupErrorHandler } from './error';
 import { authResponse } from './modules/auth/passport';
 
@@ -59,6 +59,7 @@ export default async function createHttp() {
   app.use(bodyParser.json());
   app.use(cookieParser(process.env.COOKIE_SECRET));
   app.use(SessionMiddleware.getInstance().get());
+  app.use(apiKeyMiddleware);
 
   app.use(passport.initialize());
   app.use(passport.session());

--- a/src/modules/auth/api-key-middleware.ts
+++ b/src/modules/auth/api-key-middleware.ts
@@ -1,0 +1,40 @@
+import { NextFunction, Request, Response } from 'express';
+import dataSource from '../../database';
+import { ApiKey } from './entities';
+import logger from '../../logger';
+
+export default async function apiKeyMiddleware(req: Request, res: Response, next: NextFunction) {
+  // User already found, so nothing for us to do here
+  if (req.user) next();
+
+  const rawKey = req.headers['x-authorization'];
+  if (!rawKey) {
+    next();
+    return;
+  }
+
+  // Format the key to the appropriate format
+  let key: string;
+  if (Array.isArray(rawKey)) {
+    if (rawKey.length !== 1) {
+      next();
+      return;
+    }
+    key = rawKey[0];
+  } else {
+    key = rawKey;
+  }
+
+  try {
+    // Find the user in the database
+    const identity = await dataSource.getRepository(ApiKey).findOne({ where: { key } });
+    if (identity) {
+      req.user = identity.asAuthUser();
+    }
+  } catch (e) {
+    logger.error(e);
+  } finally {
+    // Always continue
+    next();
+  }
+}

--- a/src/modules/auth/api-key-middleware.ts
+++ b/src/modules/auth/api-key-middleware.ts
@@ -2,14 +2,6 @@ import { NextFunction, Request, Response } from 'express';
 import dataSource from '../../database';
 import { ApiKey } from './entities';
 import logger from '../../logger';
-import { IntegrationUser } from './integration/entities';
-
-async function updateLastSeen(integrationUser: IntegrationUser) {
-  const repo = dataSource.getRepository(IntegrationUser);
-  await repo.update(integrationUser.id, {
-    lastSeen: new Date(),
-  });
-}
 
 export default async function apiKeyMiddleware(req: Request, res: Response, next: NextFunction) {
   // User already found, so nothing for us to do here
@@ -38,9 +30,6 @@ export default async function apiKeyMiddleware(req: Request, res: Response, next
     const identity = await dataSource.getRepository(ApiKey).findOne({ where: { key } });
     if (identity) {
       req.user = identity.asAuthUser();
-      if (identity.integrationUser) {
-        void updateLastSeen(identity.integrationUser);
-      }
     }
   } catch (e) {
     logger.error(e);

--- a/src/modules/auth/api-key-middleware.ts
+++ b/src/modules/auth/api-key-middleware.ts
@@ -7,7 +7,7 @@ export default async function apiKeyMiddleware(req: Request, res: Response, next
   // User already found, so nothing for us to do here
   if (req.user) next();
 
-  const rawKey = req.headers['x-authorization'];
+  const rawKey = req.headers['X-API-Key'];
   if (!rawKey) {
     next();
     return;

--- a/src/modules/auth/api-key-middleware.ts
+++ b/src/modules/auth/api-key-middleware.ts
@@ -1,7 +1,8 @@
 import { NextFunction, Request, Response } from 'express';
 import dataSource from '../../database';
-import { ApiKey, IntegrationUser } from './entities';
+import { ApiKey } from './entities';
 import logger from '../../logger';
+import { IntegrationUser } from './integration/entities';
 
 async function updateLastSeen(integrationUser: IntegrationUser) {
   const repo = dataSource.getRepository(IntegrationUser);

--- a/src/modules/auth/auth-service.ts
+++ b/src/modules/auth/auth-service.ts
@@ -68,14 +68,6 @@ export default class AuthService {
     });
   }
 
-  public async createIntegrationUser(
-    params: IntegrationUserCreateParams,
-  ): Promise<IntegrationUser> {
-    const integrationUser = await this.integrationUserRepository.save(params);
-    await this.createApiKey({ integrationUser });
-    return integrationUser;
-  }
-
   public async getOIDCConfig(): Promise<OidcConfig> {
     const oidcConfigRes = await fetch(process.env.OIDC_CONFIG!);
     return oidcConfigRes.json();

--- a/src/modules/auth/auth-service.ts
+++ b/src/modules/auth/auth-service.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import crypto from 'crypto';
-import { ApiKey, IntegrationUser } from './entities';
+import { ApiKey } from './entities';
+import { IntegrationUser } from './integration/entities';
 import dataSource from '../../database';
 import { Audio, LightsController, Screen } from '../root/entities';
 

--- a/src/modules/auth/auth-user.ts
+++ b/src/modules/auth/auth-user.ts
@@ -4,6 +4,10 @@ interface AuthUser {
   id: string;
   name: string;
   roles: SecurityGroup[];
+  /**
+   * List of accessible endpoints if integration user
+   */
+  endpoints?: string[];
 
   audioId?: number;
   lightsControllerId?: number;

--- a/src/modules/auth/authentication.ts
+++ b/src/modules/auth/authentication.ts
@@ -2,8 +2,6 @@ import * as express from 'express';
 import { HttpApiException, HttpStatusCode } from '../../helpers/custom-error';
 import { AuthUser } from './auth-user';
 import { SecurityGroup } from '../../helpers/security';
-import dataSource from '../../database';
-import { IntegrationUser } from './entities';
 
 /**
  * Express middleware to authenticate the user

--- a/src/modules/auth/endpoint-security.ts
+++ b/src/modules/auth/endpoint-security.ts
@@ -4,7 +4,7 @@ import IntegrationEndpointManager from './integration/integration-endpoint-manag
 
 /**
  * Add TSOA Authorization to a controller or a controller endpoint.
- * In case of SecurityNames.Integration
+ * In case of SecurityNames.Integration, register the endpoint for integration users.
  * @param name
  * @param scopes
  * @constructor

--- a/src/modules/auth/endpoint-security.ts
+++ b/src/modules/auth/endpoint-security.ts
@@ -1,6 +1,6 @@
 import { Controller, Security as TsoaSecurity } from '@tsoa/runtime';
 import { SecurityNames } from '../../helpers/security';
-import IntegrationEndpointManager from './integration/integration-endpoint-manager';
+import { IntegrationEndpointManager } from './integration';
 
 /**
  * Add TSOA Authorization to a controller or a controller endpoint.

--- a/src/modules/auth/endpoint-security.ts
+++ b/src/modules/auth/endpoint-security.ts
@@ -1,0 +1,65 @@
+import { Controller, Security as TsoaSecurity } from '@tsoa/runtime';
+import { SecurityNames } from '../../helpers/security';
+import IntegrationEndpointManager from './integration/integration-endpoint-manager';
+
+/**
+ * Add TSOA Authorization to a controller or a controller endpoint.
+ * In case of SecurityNames.Integration
+ * @param name
+ * @param scopes
+ * @constructor
+ */
+function Security(
+  name:
+    | string
+    | {
+        [name: string]: string[];
+      },
+  scopes?: string[],
+): ClassDecorator & MethodDecorator {
+  return (...args: any[]) => {
+    // Class decorator
+    if (args.length === 1) {
+      const target = args[0] as Function;
+
+      // Security for integrations can only be used on controller endpoints
+      if (name === SecurityNames.INTEGRATION) {
+        throw new Error('Integration security decorator can only be used on controller endpoints');
+      }
+    }
+
+    // Method decorator
+    if (args.length === 3) {
+      const target = args[0] as Object;
+      const propertyKey = args[1] as string | symbol;
+      const descriptor = args[2] as TypedPropertyDescriptor<any>;
+      // Security for integrations
+      if (name === SecurityNames.INTEGRATION) {
+        // Can only be assigned to controller methods
+        if (!(target instanceof Controller)) {
+          throw new Error(
+            'Integration security decorator can only be used on controller endpoints',
+          );
+        }
+
+        // Scope should equal the method name. We cannot derive this immediately from the propertyKey,
+        // because TSOA reads a controller file as a AST and thus does run the actual file and its
+        // decorators. However, overriding the @Security() decorator works!
+        if (!scopes || scopes?.length !== 1 || scopes[0] !== propertyKey) {
+          throw new Error(
+            `Integration security decorator's scope needs to equal the method's name (${scopes} != ${String(propertyKey)})`,
+          );
+        }
+
+        IntegrationEndpointManager.getInstance().addIntegrationMethod(scopes[0]);
+      }
+    }
+
+    // @ts-ignore Args can be 1 or 3 items long
+    return TsoaSecurity(name, scopes)(...args);
+  };
+}
+
+const s: typeof TsoaSecurity = Security;
+
+export default s;

--- a/src/modules/auth/entities/api-key.ts
+++ b/src/modules/auth/entities/api-key.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
 import { Audio, LightsController, Screen } from '../../root/entities';
-import IntegrationUser from './integration-user';
+import { IntegrationUser } from '../integration/entities';
 import { AuthUser } from '../auth-user';
 import { SecurityGroup } from '../../../helpers/security';
 

--- a/src/modules/auth/entities/api-key.ts
+++ b/src/modules/auth/entities/api-key.ts
@@ -1,6 +1,8 @@
 import { BaseEntity, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
 import { Audio, LightsController, Screen } from '../../root/entities';
 import IntegrationUser from './integration-user';
+import { AuthUser } from '../auth-user';
+import { SecurityGroup } from '../../../helpers/security';
 
 @Entity()
 export default class ApiKey extends BaseEntity {
@@ -22,4 +24,43 @@ export default class ApiKey extends BaseEntity {
   @OneToOne(() => IntegrationUser, { nullable: true, onDelete: 'CASCADE', eager: true })
   @JoinColumn()
   public integrationUser?: IntegrationUser | null;
+
+  public asAuthUser(): AuthUser {
+    const roles: SecurityGroup[] = [];
+    let endpoints: string[] | undefined;
+    const names: string[] = [];
+    const ids: string[] = [];
+    if (this.audio) {
+      roles.push(SecurityGroup.AUDIO_SUBSCRIBER);
+      names.push(this.audio.name);
+      ids.push(`audio${this.audio.id}`);
+    }
+    if (this.screen) {
+      roles.push(SecurityGroup.SCREEN_SUBSCRIBER);
+      names.push(this.screen.name);
+      ids.push(`screen${this.screen.id}`);
+    }
+    if (this.lightsController) {
+      roles.push(SecurityGroup.LIGHTS_SUBSCRIBER);
+      names.push(this.lightsController.name);
+      ids.push(`lightsController${this.lightsController.id}`);
+    }
+    if (this.integrationUser) {
+      roles.push(SecurityGroup.INTEGRATION_USER);
+      names.push(this.integrationUser.name);
+      ids.push(`integrationUser${this.integrationUser.id}`);
+      endpoints = this.integrationUser.endpoints;
+    }
+
+    return {
+      id: ids.join('-'),
+      name: names.join('-'),
+      roles,
+      endpoints,
+      audioId: this.audio?.id,
+      screenId: this.screen?.id,
+      lightsControllerId: this.lightsController?.id,
+      integrationUserId: this.integrationUser?.id,
+    };
+  }
 }

--- a/src/modules/auth/entities/index.ts
+++ b/src/modules/auth/entities/index.ts
@@ -1,9 +1,7 @@
 import Session from './session';
 import ApiKey from './api-key';
-import IntegrationUser from './integration-user';
 
 export { default as Session } from './session';
 export { default as ApiKey } from './api-key';
-export { default as IntegrationUser } from './integration-user';
 
-export const Entities = [Session, IntegrationUser, ApiKey];
+export const Entities = [Session, ApiKey];

--- a/src/modules/auth/entities/integration-user.ts
+++ b/src/modules/auth/entities/integration-user.ts
@@ -11,6 +11,25 @@ export default class IntegrationUser extends BaseEntity {
   name: string;
 
   /**
+   * When this integration has last made an API call
+   */
+  @Column({
+    type: 'varchar',
+    nullable: true,
+    transformer: {
+      from(value: string | null): Date | null {
+        if (value == null) return null;
+        return new Date(value);
+      },
+      to(value: Date | null): string | null {
+        if (value == null) return null;
+        return value.toISOString();
+      },
+    },
+  })
+  lastSeen: Date | null;
+
+  /**
    * List of endpoints (operationIds) this user can access
    */
   @Column({

--- a/src/modules/auth/entities/integration-user.ts
+++ b/src/modules/auth/entities/integration-user.ts
@@ -9,4 +9,23 @@ import { Column, Entity } from 'typeorm';
 export default class IntegrationUser extends BaseEntity {
   @Column({ nullable: false })
   name: string;
+
+  /**
+   * List of endpoints (operationIds) this user can access
+   */
+  @Column({
+    nullable: true,
+    type: 'varchar',
+    transformer: {
+      from(value: string | null): string[] {
+        if (value == null) return [];
+        return JSON.parse(value);
+      },
+      to(value: string[]): string | null {
+        if (value.length === 0) return null;
+        return JSON.stringify(value);
+      },
+    },
+  })
+  endpoints: string[];
 }

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,4 +1,6 @@
 import './passport';
 
 export { default as SessionMiddleware } from './session-middleware';
+export { default as apiKeyMiddleware } from './api-key-middleware';
 export { AuthUser } from './auth-user';
+export { default as Security } from './endpoint-security';

--- a/src/modules/auth/integration/README.md
+++ b/src/modules/auth/integration/README.md
@@ -2,21 +2,21 @@
 
 Aurora's goal is to integrate and synchronize many different devices and services. However, in certain cases, some
 services also wish to integrate with Aurora. The goal of integrations is to provide such a service. Only use an
-integration if the service you wish to integrate with, takes the initiative in sending information. Even though it is
+integration if the service you wish to integrate with takes the initiative in sending information. Even though it is
 theoretically possible, integrations are not designed to request data from Aurora (polling).
 
 ## Authentication
 
-Just like subscribers, `IntegrationUsers` can start a session with Aurora using and API key. You receive a cookie from
+Just like subscribers, `IntegrationUsers` can start a session with Aurora using an API key. You receive a cookie from
 the core, which you can use in all following communication. You can also use the cookie to connect to SocketIO.
 
 However, to ease the integration process, `IntegrationUsers` are also able to authenticate themselves by using HTTP
-headers. Simply put the API key in the `X-Authorization` header of every request to authenticate that single HTTP
+headers. Simply put the API key in the `X-API-Key` header of every request to authenticate that single HTTP
 request. For integrations, this is the preferred authentication method.
 
 ## Authorization
 
-For security purposes, each integration gets assigned a specific subset of endpoints that integration can access.
+For security purposes, each integration is assigned a specific subset of endpoints that integration can access.
 To use an endpoint, the endpoint needs to be marked in Aurora Core first. By adding the
 `@Security(SecurityNames.INTEGRATION, <endpoint name>)` decorator to a controller method, this endpoint is marked as
 both being accessible for integrations with access to that endpoint, and as an endpoint that integrations can use

--- a/src/modules/auth/integration/README.md
+++ b/src/modules/auth/integration/README.md
@@ -1,0 +1,23 @@
+# Aurora Integrations
+
+Aurora's goal is to integrate and synchronize many different devices and services. However, in certain cases, some
+services also wish to integrate with Aurora. The goal of integrations is to provide such a service. Only use an
+integration if the service you wish to integrate with, takes the initiative in sending information. Even though it is
+theoretically possible, integrations are not designed to request data from Aurora (polling).
+
+## Authentication
+
+Just like subscribers, `IntegrationUsers` can start a session with Aurora using and API key. You receive a cookie from
+the core, which you can use in all following communication. You can also use the cookie to connect to SocketIO.
+
+However, to ease the integration process, `IntegrationUsers` are also able to authenticate themselves by using HTTP
+headers. Simply put the API key in the `X-Authorization` header of every request to authenticate that single HTTP
+request. For integrations, this is the preferred authentication method.
+
+## Authorization
+
+For security purposes, each integration gets assigned a specific subset of endpoints that integration can access.
+To use an endpoint, the endpoint needs to be marked in Aurora Core first. By adding the
+`@Security(SecurityNames.INTEGRATION, <endpoint name>)` decorator to a controller method, this endpoint is marked as
+both being accessible for integrations with access to that endpoint, and as an endpoint that integrations can use
+(so both sides of the arrow). In the backoffice, admins can assign endpoints to integrations.

--- a/src/modules/auth/integration/README.md
+++ b/src/modules/auth/integration/README.md
@@ -20,4 +20,5 @@ For security purposes, each integration gets assigned a specific subset of endpo
 To use an endpoint, the endpoint needs to be marked in Aurora Core first. By adding the
 `@Security(SecurityNames.INTEGRATION, <endpoint name>)` decorator to a controller method, this endpoint is marked as
 both being accessible for integrations with access to that endpoint, and as an endpoint that integrations can use
-(so both sides of the arrow). In the backoffice, admins can assign endpoints to integrations.
+(so both sides of the arrow). **Make sure that you use the custom @Security() decorator from the `auth` module and NOT
+the TSOA version!** In the backoffice, admins can assign endpoints to integrations.

--- a/src/modules/auth/integration/entities/index.ts
+++ b/src/modules/auth/integration/entities/index.ts
@@ -1,0 +1,5 @@
+import IntegrationUser from './integration-user';
+
+export { default as IntegrationUser } from './integration-user';
+
+export const Entities = [IntegrationUser];

--- a/src/modules/auth/integration/entities/integration-user.ts
+++ b/src/modules/auth/integration/entities/integration-user.ts
@@ -1,4 +1,4 @@
-import BaseEntity from '../../root/entities/base-entity';
+import BaseEntity from '../../../root/entities/base-entity';
 import { Column, Entity } from 'typeorm';
 
 @Entity()

--- a/src/modules/auth/integration/index.ts
+++ b/src/modules/auth/integration/index.ts
@@ -1,3 +1,4 @@
 export { default as IntegrationEndpointManager } from './integration-endpoint-manager';
 export { IntegrationUserController } from './integration-user-controller';
 export { default as IntegrationUserService } from './integration-user-service';
+export { default as IntegrationUserActivityMiddleware } from './integration-user-activity-middleware';

--- a/src/modules/auth/integration/index.ts
+++ b/src/modules/auth/integration/index.ts
@@ -1,0 +1,3 @@
+export { default as IntegrationEndpointManager } from './integration-endpoint-manager';
+export { IntegrationUserController } from './integration-user-controller';
+export { default as IntegrationUserService } from './integration-user-service';

--- a/src/modules/auth/integration/integration-endpoint-manager.ts
+++ b/src/modules/auth/integration/integration-endpoint-manager.ts
@@ -1,0 +1,31 @@
+/**
+ * Class to keep track of all endpoint operationIds that can be accessed by integration users.
+ */
+export default class IntegrationEndpointManager {
+  // Must be a singleton, as this object will be accessed by decorators
+  private static instance: IntegrationEndpointManager;
+
+  private integrationMethods: string[] = [];
+
+  public static getInstance() {
+    if (this.instance == null) {
+      this.instance = new IntegrationEndpointManager();
+    }
+    return this.instance;
+  }
+
+  /**
+   * Mark a method as one that can be used by integration users
+   * @param methodName
+   */
+  public addIntegrationMethod(methodName: string): void {
+    this.integrationMethods.push(methodName);
+  }
+
+  /**
+   * Get all methods that have been marked as integration methods
+   */
+  public getIntegrationMethods(): string[] {
+    return this.integrationMethods;
+  }
+}

--- a/src/modules/auth/integration/integration-user-activity-middleware.ts
+++ b/src/modules/auth/integration/integration-user-activity-middleware.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from 'express';
+import dataSource from '../../../database';
+import { IntegrationUser } from './entities';
+
+/**
+ * Middleware to update the "last seen" field on the currently authenticated IntegrationUser.
+ */
+export default async function IntegrationUserActivityMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (req.user && req.user.integrationUserId) {
+    const repo = dataSource.getRepository(IntegrationUser);
+    await repo.update(req.user.integrationUserId, {
+      lastSeen: new Date(),
+    });
+  }
+  next();
+}

--- a/src/modules/auth/integration/integration-user-controller.ts
+++ b/src/modules/auth/integration/integration-user-controller.ts
@@ -9,8 +9,6 @@ import IntegrationUserService, {
   IntegrationUserUpdateRequest,
 } from './integration-user-service';
 import AuthService from '../auth-service';
-import { HttpApiException } from '../../../helpers/custom-error';
-import { HttpStatusCode } from 'axios';
 
 @Tags('User')
 @Route('user/integration')

--- a/src/modules/auth/integration/integration-user-controller.ts
+++ b/src/modules/auth/integration/integration-user-controller.ts
@@ -1,0 +1,91 @@
+import { Controller, Patch } from '@tsoa/runtime';
+import { Body, Delete, Get, Post, Route, Tags } from 'tsoa';
+import { Security } from '../index';
+import { SecurityNames } from '../../../helpers/security';
+import { securityGroups } from '../../../helpers/security-groups';
+import IntegrationUserService, {
+  IntegrationUserCreateRequest,
+  IntegrationUserResponse,
+  IntegrationUserUpdateRequest,
+} from './integration-user-service';
+import AuthService from '../auth-service';
+import { HttpApiException } from '../../../helpers/custom-error';
+import { HttpStatusCode } from 'axios';
+
+@Tags('User')
+@Route('user/integration')
+export class IntegrationUserController extends Controller {
+  /**
+   * Get a list of all endpoints that an integration user could access.
+   */
+  @Security(SecurityNames.LOCAL, securityGroups.integrationUsers.privileged)
+  @Get('endpoints')
+  public getIntegrationEndpoints(): string[] {
+    const service = new IntegrationUserService();
+    return service.getIntegrationEndpoints();
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.integrationUsers.privileged)
+  @Get('')
+  public async getAllIntegrationUsers(): Promise<IntegrationUserResponse[]> {
+    const service = new IntegrationUserService();
+    const users = await service.getAllIntegrationUsers();
+    return users.map((u) => service.asResponse(u));
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.integrationUsers.privileged)
+  @Get('{id}')
+  public async getSingleIntegrationUser(id: number): Promise<IntegrationUserResponse> {
+    const service = new IntegrationUserService();
+    const user = await service.getSingleIntegrationUser(id);
+    return service.asResponse(user);
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.integrationUsers.privileged)
+  @Get('{id}/key')
+  public async getIntegrationUserKey(id: number): Promise<string> {
+    const integrationService = new IntegrationUserService();
+    const user = await integrationService.getSingleIntegrationUser(id);
+
+    const authService = new AuthService();
+    let key = await authService.getIntegrationUserApiKey(user);
+    if (!key) {
+      // Somehow the key does not exist, so let's create one.
+      key = await authService.createApiKey({ integrationUser: user });
+    }
+    return key.key;
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.integrationUsers.privileged)
+  @Post('')
+  public async createIntegrationUser(
+    @Body() body: IntegrationUserCreateRequest,
+  ): Promise<IntegrationUserResponse> {
+    const service = new IntegrationUserService();
+    service.validateEndpoints(body.endpoints);
+    const user = await service.createIntegrationUser(body);
+    return service.asResponse(user);
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.integrationUsers.privileged)
+  @Patch('{id}')
+  public async updateIntegrationUser(
+    id: number,
+    @Body() body: IntegrationUserUpdateRequest,
+  ): Promise<IntegrationUserResponse> {
+    const service = new IntegrationUserService();
+    if (body.endpoints) {
+      service.validateEndpoints(body.endpoints);
+    }
+    const user = await service.updateIntegrationUser(id, body);
+    return service.asResponse(user);
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.integrationUsers.privileged)
+  @Delete('{id}')
+  public async deleteIntegrationUser(id: number): Promise<void> {
+    const service = new IntegrationUserService();
+    await service.getSingleIntegrationUser(id);
+    await service.deleteIntegrationUser(id);
+  }
+}

--- a/src/modules/auth/integration/integration-user-service.ts
+++ b/src/modules/auth/integration/integration-user-service.ts
@@ -7,7 +7,9 @@ import IntegrationEndpointManager from './integration-endpoint-manager';
 import AuthService from '../auth-service';
 
 export interface IntegrationUserResponse
-  extends Pick<IntegrationUser, 'id' | 'name' | 'endpoints'> {}
+  extends Pick<IntegrationUser, 'id' | 'name' | 'endpoints'> {
+  lastSeen: string | null;
+}
 
 export interface IntegrationUserCreateRequest extends Pick<IntegrationUser, 'name' | 'endpoints'> {}
 
@@ -25,6 +27,7 @@ export default class IntegrationUserService {
       id: user.id,
       name: user.name,
       endpoints: user.endpoints,
+      lastSeen: user.lastSeen?.toISOString() ?? null,
     };
   }
 

--- a/src/modules/auth/integration/integration-user-service.ts
+++ b/src/modules/auth/integration/integration-user-service.ts
@@ -1,5 +1,5 @@
 import { Repository } from 'typeorm';
-import { IntegrationUser } from '../entities';
+import IntegrationUser from './entities/integration-user';
 import dataSource from '../../../database';
 import { HttpApiException } from '../../../helpers/custom-error';
 import { HttpStatusCode } from 'axios';

--- a/src/modules/auth/integration/integration-user-service.ts
+++ b/src/modules/auth/integration/integration-user-service.ts
@@ -1,0 +1,106 @@
+import { Repository } from 'typeorm';
+import { IntegrationUser } from '../entities';
+import dataSource from '../../../database';
+import { HttpApiException } from '../../../helpers/custom-error';
+import { HttpStatusCode } from 'axios';
+import IntegrationEndpointManager from './integration-endpoint-manager';
+import AuthService from '../auth-service';
+
+export interface IntegrationUserResponse
+  extends Pick<IntegrationUser, 'id' | 'name' | 'endpoints'> {}
+
+export interface IntegrationUserCreateRequest extends Pick<IntegrationUser, 'name' | 'endpoints'> {}
+
+export interface IntegrationUserUpdateRequest extends Partial<IntegrationUserCreateRequest> {}
+
+export default class IntegrationUserService {
+  private repo: Repository<IntegrationUser>;
+
+  constructor(repo?: Repository<IntegrationUser>) {
+    this.repo = repo ?? dataSource.getRepository(IntegrationUser);
+  }
+
+  public static asResponse(user: IntegrationUser): IntegrationUserResponse {
+    return {
+      id: user.id,
+      name: user.name,
+      endpoints: user.endpoints,
+    };
+  }
+
+  public asResponse(user: IntegrationUser): IntegrationUserResponse {
+    return IntegrationUserService.asResponse(user);
+  }
+
+  public async getAllIntegrationUsers(): Promise<IntegrationUser[]> {
+    return this.repo.find();
+  }
+
+  public async getSingleIntegrationUser(id: number): Promise<IntegrationUser> {
+    const user = await this.repo.findOne({ where: { id } });
+    if (!user) {
+      throw new HttpApiException(
+        HttpStatusCode.NotFound,
+        `Integration user with ID "${id}" not found.`,
+      );
+    }
+    return user;
+  }
+
+  public async createIntegrationUser(
+    params: IntegrationUserCreateRequest,
+  ): Promise<IntegrationUser> {
+    const integrationUser = await this.repo.save(params);
+    const apiService = new AuthService();
+    await apiService.createApiKey({ integrationUser });
+    return integrationUser;
+  }
+
+  public async updateIntegrationUser(
+    id: number,
+    params: IntegrationUserUpdateRequest,
+  ): Promise<IntegrationUser> {
+    const user = await this.getSingleIntegrationUser(id);
+
+    if (params.name != undefined) {
+      user.name = params.name;
+    }
+    if (params.endpoints != undefined) {
+      user.endpoints = params.endpoints;
+    }
+
+    return this.repo.save(user);
+  }
+
+  public async deleteIntegrationUser(id: number): Promise<void> {
+    await this.repo.delete(id);
+  }
+
+  /**
+   * Get a list of all endpoints that can be used by integration users
+   */
+  public getIntegrationEndpoints(): string[] {
+    const manager = IntegrationEndpointManager.getInstance();
+    return manager.getIntegrationMethods();
+  }
+
+  /**
+   * Throw an HttpApiException if the given list of endpoints contains names that are not
+   * registered as integration endpoints.
+   * @param endpoints
+   * @throws HttpApiException list of endpoints contains invalid endpoints
+   */
+  public validateEndpoints(endpoints: string[]): void {
+    const integrationEndpoints = this.getIntegrationEndpoints();
+    const invalid = endpoints.filter((e) => {
+      // Element should only be returned if it is not in the integration methods
+      return !integrationEndpoints.includes(e);
+    });
+    if (invalid.length > 0) {
+      throw new HttpApiException(
+        HttpStatusCode.BadRequest,
+        `Invalid endpoints: [${invalid.join(', ')}]`,
+      );
+    }
+  }
+}

--- a/src/modules/auth/passport/api-key-strategy.ts
+++ b/src/modules/auth/passport/api-key-strategy.ts
@@ -1,12 +1,9 @@
 import passport from 'passport';
 import { Strategy as CustomStrategy } from 'passport-custom';
-import { Request as ExRequest, Response as ExResponse } from 'express';
 import { HttpStatusCode } from 'axios';
 import { HttpApiException } from '../../../helpers/custom-error';
 import database from '../../../database';
 import { ApiKey } from '../entities';
-import { SecurityGroup } from '../../../helpers/security';
-import { AuthUser } from '../auth-user';
 
 passport.use(
   'apikey',
@@ -24,38 +21,6 @@ passport.use(
       return;
     }
 
-    const roles: string[] = [];
-    const names: string[] = [];
-    const ids: string[] = [];
-    if (identity.audio) {
-      roles.push(SecurityGroup.AUDIO_SUBSCRIBER);
-      names.push(identity.audio.name);
-      ids.push(`audio${identity.audio.id}`);
-    }
-    if (identity.screen) {
-      roles.push(SecurityGroup.SCREEN_SUBSCRIBER);
-      names.push(identity.screen.name);
-      ids.push(`screen${identity.screen.id}`);
-    }
-    if (identity.lightsController) {
-      roles.push(SecurityGroup.LIGHTS_SUBSCRIBER);
-      names.push(identity.lightsController.name);
-      ids.push(`lightsController${identity.lightsController.id}`);
-    }
-    if (identity.integrationUser) {
-      roles.push(SecurityGroup.INTEGRATION_USER);
-      names.push(identity.integrationUser.name);
-      ids.push(`integrationUser${identity.integrationUser.id}`);
-    }
-
-    callback(null, {
-      id: ids.join('-'),
-      name: names.join('-'),
-      roles,
-      audioId: identity.audio?.id,
-      screenId: identity.screen?.id,
-      lightsControllerId: identity.lightsController?.id,
-      integrationUserId: identity.integrationUser?.id,
-    } as AuthUser);
+    callback(null, identity.asAuthUser());
   }),
 );

--- a/src/modules/beats/artificial-beat-controller.ts
+++ b/src/modules/beats/artificial-beat-controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from '@tsoa/runtime';
-import { Body, Delete, Get, Post, Request, Route, Security, Tags } from 'tsoa';
+import { Body, Delete, Get, Post, Request, Route, Tags } from 'tsoa';
 import { Request as ExpressRequest } from 'express';
 import {
   ArtificialBeatGenerator,
@@ -8,13 +8,15 @@ import {
 import { SecurityNames } from '../../helpers/security';
 import logger from '../../logger';
 import { securityGroups } from '../../helpers/security-groups';
+import { Security } from '../auth';
 
 @Tags('Artificial Beat Generator')
 @Route('beat-generator')
 export class ArtificialBeatController extends Controller {
   @Security(SecurityNames.LOCAL, securityGroups.beats.base)
+  @Security(SecurityNames.INTEGRATION, ['getArtificialBeatGenerator'])
   @Get('')
-  public getArtificalBeatGenerator(): ArtificialBeatGeneratorParams | null {
+  public getArtificialBeatGenerator(): ArtificialBeatGeneratorParams | null {
     const generator = ArtificialBeatGenerator.getInstance();
     if (!generator.active || !generator.bpm) return null;
     return {
@@ -23,6 +25,7 @@ export class ArtificialBeatController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.beats.base)
+  @Security(SecurityNames.INTEGRATION, ['startArtificialBeatGenerator'])
   @Post('')
   public startArtificialBeatGenerator(
     @Request() req: ExpressRequest,
@@ -35,6 +38,7 @@ export class ArtificialBeatController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.beats.base)
+  @Security(SecurityNames.INTEGRATION, ['stopArtificialBeatGenerator'])
   @Delete('')
   public stopArtificialBeatGenerator(@Request() req: ExpressRequest) {
     logger.audit(req.user, 'Stop Artificial Beat Generator.');

--- a/src/modules/orders/order-controller.ts
+++ b/src/modules/orders/order-controller.ts
@@ -28,6 +28,9 @@ export class OrderController extends Controller {
     return OrderManager.getInstance().getOrders();
   }
 
+  /**
+   * Add a new order to be propagated to all connected screens.
+   */
   @Security(SecurityNames.LOCAL, securityGroups.orders.privileged)
   @Security(SecurityNames.INTEGRATION, ['addOrder'])
   @Post('')

--- a/src/modules/orders/order-controller.ts
+++ b/src/modules/orders/order-controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Header, Response, TsoaResponse } from '@tsoa/runtime';
 import { createVerify } from 'crypto';
 import { FeatureEnabled, ServerSettingsStore } from '../server-settings';
-import { Body, Delete, Get, Post, Res, Route, Security, Tags } from 'tsoa';
+import { Body, Delete, Get, Post, Res, Route, Tags } from 'tsoa';
 import { SecurityNames } from '../../helpers/security';
 import { securityGroups } from '../../helpers/security-groups';
 import OrderManager from './order-manager';
 import { OrderSettings } from './order-settings';
+import { Security } from '../auth';
 
 interface OrderRequest {
   orderNumber: number;
@@ -28,6 +29,7 @@ export class OrderController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.orders.privileged)
+  @Security(SecurityNames.INTEGRATION, ['addOrder'])
   @Post('')
   @Response<string>(409, 'Endpoint is disabled in the server settings')
   public async addOrder(@Body() orderRequest: OrderRequest) {

--- a/src/seed/seed.ts
+++ b/src/seed/seed.ts
@@ -21,6 +21,7 @@ import { ColorEffects } from '../modules/lights/effects/color/color-effects';
 import { MovementEffects } from '../modules/lights/effects/movement/movement-effetcs';
 import { TimedEvent } from '../modules/timed-events/entities';
 import AuthService from '../modules/auth/auth-service';
+import { IntegrationUserService } from '../modules/auth/integration';
 
 export default async function seedDatabase() {
   const timedEventsRepo = dataSource.getRepository(TimedEvent);
@@ -56,7 +57,14 @@ export default async function seedDatabase() {
     name: 'PCGEWISINFO',
     defaultHandler: CarouselPosterHandler.name,
   });
-  await new AuthService().createIntegrationUser({ name: 'BPM-script' });
+  await new IntegrationUserService().createIntegrationUser({
+    name: 'BPM-script',
+    endpoints: [
+      'startArtificialBeatGenerator',
+      'stopArtificialBeatGenerator',
+      'getArtificialBeatGenerator',
+    ],
+  });
 
   const rootLightsService = new RootLightsService();
   const controller = await rootLightsService.createController({ name: 'GEWIS-BAR' });

--- a/tsoa.json
+++ b/tsoa.json
@@ -14,7 +14,7 @@
       },
       "integration": {
         "type": "apiKey",
-        "name": "X-Authorization",
+        "name": "X-API-Key",
         "in": "header"
       }
     },

--- a/tsoa.json
+++ b/tsoa.json
@@ -11,6 +11,11 @@
         "type": "apiKey",
         "name": "connect.sid",
         "in": "cookie"
+      },
+      "integration": {
+        "type": "apiKey",
+        "name": "X-Authorization",
+        "in": "header"
       }
     },
     "outputDirectory": "build",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds basic functionality regarding new `IntegrationUsers`, which can be used to integrate Aurora with other services. In the documentation, _integrations_ are _integration users_ are used somewhat interchangeably. This is because _integrations_ represent the use of linking Aurora to different, external services. _Integration Users_ however represent the means of achieving this goal: they are a type of "user" (a machine) that can communicate with Aurora.
- Create, update, delete integration users.
- View the API key of each integration users.
- Mark endpoints for use by integration users with the existing `@Security()` decorator.
  - NOTE: this requires one to use the new (overriden) `@Security()` decorator, and not the TSOA variant!
- Assign a subset of endpoints to each integration user for security purposes.
- Add header-based authentication/authorization for integration users (via the `X-Authorization` header).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-core/issues/91.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_