### PR TITLE
chore(orders): deprecate endpoint to receive orders via webhooks

### DIFF
--- a/src/modules/auth/api-key-middleware.ts
+++ b/src/modules/auth/api-key-middleware.ts
@@ -5,7 +5,10 @@ import logger from '../../logger';
 
 export default async function apiKeyMiddleware(req: Request, res: Response, next: NextFunction) {
   // User already found, so nothing for us to do here
-  if (req.user) next();
+  if (req.user) {
+    next();
+    return;
+  }
 
   const rawKey = req.headers['X-API-Key'];
   if (!rawKey) {

--- a/src/modules/orders/order-controller.ts
+++ b/src/modules/orders/order-controller.ts
@@ -41,6 +41,10 @@ export class OrderController extends Controller {
     return manager.getOrders();
   }
 
+  /**
+   * @deprecated Please migrate to the new IntegrationUsers-based approach. See
+   * https://github.com/GEWIS/aurora-core/blob/develop/src/modules/auth/integration/README.md.
+   */
   @Post('webhook')
   @FeatureEnabled('Orders.WebhookPublicKeyURL')
   @Response<string>(409, 'Endpoint is disabled in the server settings')

--- a/src/modules/orders/order-settings.ts
+++ b/src/modules/orders/order-settings.ts
@@ -1,7 +1,15 @@
 export interface OrderSettings {
   Orders: boolean;
   'Orders.DefaultTimeoutSeconds': number;
+  /**
+   * @deprecated Please migrate to the new IntegrationUsers-based approach. See
+   * https://github.com/GEWIS/aurora-core/blob/develop/src/modules/auth/integration/README.md.
+   */
   'Orders.WebhookPublicKeyURL': string;
+  /**
+   * @deprecated Please migrate to the new IntegrationUsers-based approach. See
+   * https://github.com/GEWIS/aurora-core/blob/develop/src/modules/auth/integration/README.md.
+   */
   'Orders.WebhookPublicKeyExpirySeconds': number;
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The Hubble-specific endpoint to receive orders via webhooks has been deprecated. Instead, please migrate to the new Integration Users (see https://github.com/GEWIS/aurora-core/pull/97). If this cannot be implemented on the Hubble-side, a small "middleware application" should be implemented to expose a webhook and propagate the call to Aurora (like with https://github.com/GEWIS/food-hubble-cafe).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Style _(Change that do not affect the functionality of the code)_