### PR TITLE
feat(colors): add separate color definitions for fixtures with only basic LED types

### DIFF
--- a/src/modules/lights/color-definitions.ts
+++ b/src/modules/lights/color-definitions.ts
@@ -42,6 +42,7 @@ export type RgbColorSpecification = {
   alternative: WheelColor;
   complementary: RgbColor[];
   hex: HexColor;
+  definitionLimited: Pick<IColorsRgb, 'redChannel' | 'greenChannel' | 'blueChannel'>;
 };
 
 export type RgbColorSet = {
@@ -77,6 +78,11 @@ export const rgbColorDefinitions: RgbColorSet = {
     alternative: WheelColor.WHITE,
     complementary: [],
     hex: '#ffffff',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 255,
+      blueChannel: 255,
+    },
   },
   [RgbColor.RED]: {
     definition: {
@@ -100,6 +106,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#ff1919',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 0,
+      blueChannel: 0,
+    },
   },
   [RgbColor.GREEN]: {
     definition: {
@@ -127,6 +138,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIGHTPINK,
     ],
     hex: '#00e60c',
+    definitionLimited: {
+      redChannel: 0,
+      greenChannel: 255,
+      blueChannel: 0,
+    },
   },
   [RgbColor.BLUE]: {
     definition: {
@@ -152,6 +168,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#0000ff',
+    definitionLimited: {
+      redChannel: 0,
+      greenChannel: 0,
+      blueChannel: 255,
+    },
   },
   [RgbColor.YELLOW]: {
     definition: {
@@ -174,6 +195,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#fba900',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 124,
+      blueChannel: 0,
+    },
   },
   [RgbColor.LIGHTBLUE]: {
     definition: {
@@ -199,6 +225,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#6a6aff',
+    definitionLimited: {
+      redChannel: 98,
+      greenChannel: 98,
+      blueChannel: 255,
+    },
   },
   [RgbColor.ORANGE]: {
     definition: {
@@ -222,6 +253,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#ff8000',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 90,
+      blueChannel: 0,
+    },
   },
   [RgbColor.ROSERED]: {
     definition: {
@@ -244,6 +280,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#ff3a7c',
+    definitionLimited: {
+      redChannel: 217,
+      greenChannel: 32,
+      blueChannel: 32,
+    },
   },
   [RgbColor.PURPLE]: {
     definition: {
@@ -270,6 +311,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#ff00f9',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 0,
+      blueChannel: 255,
+    },
   },
   [RgbColor.CYAN]: {
     definition: {
@@ -295,6 +341,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#00d7fc',
+    definitionLimited: {
+      redChannel: 0,
+      blueChannel: 255,
+      greenChannel: 255,
+    },
   },
   [RgbColor.PINK]: {
     definition: {
@@ -318,6 +369,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#f948c4',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 0,
+      blueChannel: 128,
+    },
   },
   [RgbColor.GOLD]: {
     definition: {
@@ -342,6 +398,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#ffbf00',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 92,
+      blueChannel: 0,
+    },
   },
   [RgbColor.BROWN]: {
     definition: {
@@ -365,6 +426,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#ff4d00',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 58,
+      blueChannel: 0,
+    },
   },
   [RgbColor.LIGHTPINK]: {
     definition: {
@@ -387,6 +453,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIME,
     ],
     hex: '#fc8ddb',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 50,
+      blueChannel: 189,
+    },
   },
   [RgbColor.LIME]: {
     definition: {
@@ -415,6 +486,11 @@ export const rgbColorDefinitions: RgbColorSet = {
       RgbColor.LIGHTPINK,
     ],
     hex: '#80ff00',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 255,
+      blueChannel: 0,
+    },
   },
   [RgbColor.BLINDINGWHITE]: {
     definition: {
@@ -429,6 +505,11 @@ export const rgbColorDefinitions: RgbColorSet = {
     alternative: WheelColor.WHITE,
     complementary: [],
     hex: '#ffffff',
+    definitionLimited: {
+      redChannel: 255,
+      greenChannel: 255,
+      blueChannel: 255,
+    },
   },
   [RgbColor.UV]: {
     definition: {
@@ -443,6 +524,11 @@ export const rgbColorDefinitions: RgbColorSet = {
     alternative: WheelColor.WHITE,
     complementary: [],
     hex: '#330066',
+    definitionLimited: {
+      redChannel: 0,
+      greenChannel: 0,
+      blueChannel: 0,
+    },
   },
 };
 

--- a/src/modules/lights/entities/colors-rgb.ts
+++ b/src/modules/lights/entities/colors-rgb.ts
@@ -57,8 +57,8 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
   };
 
   /**
-   * Returns whether this fixture can use the full color definition (true) or it must
-   * use the limited definition.
+   * Returns whether this fixture can use the full color definition (true) or it must use the
+   * limited definition. Depends on which type of LEDs the color's definition requires.
    */
   public canShowFullColor(color: RgbColorSpecification): boolean {
     if (color.definition.coldWhiteChannel && this.coldWhiteChannel == null) return false;
@@ -82,7 +82,8 @@ export default class ColorsRgb extends Colors implements IColorsRgb {
       return;
     }
 
-    if (this.canShowFullColor(spec)) {
+    // Blinding white enables all (present) LED types, so no filter is necessary
+    if (this.canShowFullColor(spec) || spec === rgbColorDefinitions[RgbColor.BLINDINGWHITE]) {
       this.currentValues = spec.definition;
     } else {
       this.currentValues = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Currently, Aurora uses a color's hex definition in case a RGB fixture does not have colors like cold white, warm white, or amber. This look decent, but these hex colors are optimized for displays and not for things like LED strips, fixtures with only RGB, or disco floors. So, each color needs a separate, minimal definition that only uses RGB to define a color. This makes Aurora compatible with any type of LED.

These limited definitions are determined manually using the spots in the GEWIS room (Eurolite LED 7C-7). They are pretty similar to their full-definition counterparts, but having less LED types means the amount of colors are more limited.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-core/issues/93.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_