### PR TITLE
feat(screen): add scale factor property to screen entity to support more resolutions than only full HD

### DIFF
--- a/src/helpers/security-groups.ts
+++ b/src/helpers/security-groups.ts
@@ -135,6 +135,7 @@ export const securityGroups = {
   screen: {
     base: allSecurityGroups,
     privileged: [SecurityGroup.ADMIN],
+    subscriber: [SecurityGroup.SCREEN_SUBSCRIBER],
   },
   lightOperation: {
     base: baseSecurityGroups,

--- a/src/modules/root/entities/screen.ts
+++ b/src/modules/root/entities/screen.ts
@@ -1,5 +1,11 @@
-import { Entity } from 'typeorm';
+import { Column, Entity } from 'typeorm';
 import SubscribeEntity from './subscribe-entity';
 
 @Entity()
-export default class Screen extends SubscribeEntity {}
+export default class Screen extends SubscribeEntity {
+  /**
+   * Display scale factor. Defaults to 1 (1920x1080)
+   */
+  @Column({ nullable: false, default: 1 })
+  scaleFactor: number;
+}

--- a/src/modules/root/handler-controller.ts
+++ b/src/modules/root/handler-controller.ts
@@ -105,7 +105,7 @@ export class HandlerController extends Controller {
     return this.handlersManager.getHandlers(Screen).map((h) => ({
       name: h.constructor.name,
       id: h.identifier,
-      entities: h.entities.map((screen) => RootScreenService.toScreenResponse(screen)),
+      entities: h.entities.map((screen) => RootScreenService.toScreenResponse(screen as Screen)),
     }));
   }
 

--- a/src/modules/root/root-screen-controller.ts
+++ b/src/modules/root/root-screen-controller.ts
@@ -1,8 +1,10 @@
-import { Body, Get, Post, Route, Security, Tags } from 'tsoa';
-import { Controller } from '@tsoa/runtime';
+import { Body, Get, Post, Route, Security, Tags, Request } from 'tsoa';
+import { Controller, Path } from '@tsoa/runtime';
+import { Request as ExpressRequest } from 'express';
 import RootScreenService, { ScreenCreateParams, ScreenResponse } from './root-screen-service';
 import { SecurityNames } from '../../helpers/security';
 import { securityGroups } from '../../helpers/security-groups';
+import { HttpApiException } from '../../helpers/custom-error';
 
 @Route('screen')
 @Tags('Screens')
@@ -12,6 +14,31 @@ export class RootScreenController extends Controller {
   public async getScreens(): Promise<ScreenResponse[]> {
     const screens = await new RootScreenService().getAllScreens();
     return screens.map((s) => RootScreenService.toScreenResponse(s));
+  }
+
+  /**
+   * Get own screen entity if authenticated user is a screen
+   */
+  @Security(SecurityNames.LOCAL, securityGroups.screen.subscriber)
+  @Get('me')
+  public async getOwnScreen(@Request() req: ExpressRequest): Promise<ScreenResponse> {
+    const screenId = req.user?.screenId;
+    if (!screenId) {
+      throw new HttpApiException(400, 'Authenticated user is not a screen subscriber.');
+    }
+
+    return this.getSingleScreen(screenId);
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.screen.base)
+  @Get('{id}')
+  public async getSingleScreen(@Path() id: number): Promise<ScreenResponse> {
+    const screen = await new RootScreenService().getSingleScreen(id);
+    if (screen == null) {
+      throw new HttpApiException(404, `Screen with id "${id}" not found.`);
+    }
+
+    return RootScreenService.toScreenResponse(screen);
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.screen.privileged)

--- a/src/modules/root/root-screen-service.ts
+++ b/src/modules/root/root-screen-service.ts
@@ -4,9 +4,10 @@ import dataSource from '../../database';
 import AuthService from '../auth/auth-service';
 
 export interface ScreenResponse
-  extends Pick<Screen, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'socketIds'> {}
+  extends Pick<Screen, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'socketIds' | 'scaleFactor'> {}
 
-export interface ScreenCreateParams extends Pick<Screen, 'name' | 'defaultHandler'> {}
+export interface ScreenCreateParams
+  extends Pick<Screen, 'name' | 'defaultHandler' | 'scaleFactor'> {}
 
 export default class RootScreenService {
   private repository: Repository<Screen>;
@@ -22,6 +23,7 @@ export default class RootScreenService {
       updatedAt: screen.updatedAt,
       name: screen.name,
       socketIds: screen.socketIds,
+      scaleFactor: screen.scaleFactor,
     };
   }
 

--- a/src/seed/seed.ts
+++ b/src/seed/seed.ts
@@ -48,14 +48,17 @@ export default async function seedDatabase() {
   await rootScreenService.createScreen({
     name: 'PCGEWISB-links',
     defaultHandler: CarouselPosterHandler.name,
+    scaleFactor: 1,
   });
   await rootScreenService.createScreen({
     name: 'PCGEWISB-rechts',
     defaultHandler: CarouselPosterHandler.name,
+    scaleFactor: 1,
   });
   await rootScreenService.createScreen({
     name: 'PCGEWISINFO',
     defaultHandler: CarouselPosterHandler.name,
+    scaleFactor: 1,
   });
   await new IntegrationUserService().createIntegrationUser({
     name: 'BPM-script',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This PR adds a new attribute to screen entities, namely `scaleFactor`. As the name implies, this is the scaling factor that should be applied to the screen. It works like the scale factor you have in Windows: when you have a 4k display and set the `scaleFactor` to `2`, everything on screen will be rendered twice as big, causing it to act just like a full HD display. This is necessary, as all UI in the client is designed for 1920x1080 displays.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_