### PR TITLE
Add `skip` endpoint to spotify module

### DIFF
--- a/src/modules/spotify/spotify-controller.ts
+++ b/src/modules/spotify/spotify-controller.ts
@@ -183,4 +183,13 @@ export class SpotifyController extends Controller {
   public getSpotifyCurrentlyPlaying() {
     return SpotifyTrackHandler.getInstance().musicEmitter.getCurrentlyPlayingTrack;
   }
+
+  /**
+   * Skip the currently playing Spotify track.
+   */
+  @Security(SecurityNames.LOCAL, securityGroups.spotify.base)
+  @Post('skip')
+  public async skipSpotifyTrack(): Promise<void> {
+    return SpotifyTrackHandler.getInstance().skipToNext();
+  }
 }

--- a/src/modules/spotify/spotify-track-handler.ts
+++ b/src/modules/spotify/spotify-track-handler.ts
@@ -94,6 +94,22 @@ export default class SpotifyTrackHandler {
   }
 
   /**
+   * Skips to the next track.
+   */
+  public async skipToNext() {
+    if (!this.api.client || !this.playState || !this.playState.device || !this.playState.device.id){
+      logger.trace('Cannot skip to next track, no Spotify user or device');
+      return;
+    }
+
+    try {
+      await this.api.client?.player.skipToNext(this.playState.device.id);
+    } catch (e) {
+      logger.warn(e);
+    }
+  }
+
+  /**
    * Main event loop to get the currently playing song
    * @private
    */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
Skips the current song.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- New feature _(non-breaking change which adds functionality)_